### PR TITLE
feat(api): RBAC role-permission linking and permission guards

### DIFF
--- a/api.orchestra.com/src/database/migrations/1769778000000-CreateUserPermission.ts
+++ b/api.orchestra.com/src/database/migrations/1769778000000-CreateUserPermission.ts
@@ -1,0 +1,48 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class CreateUserPermission1769778000000 implements MigrationInterface {
+  name = 'CreateUserPermission1769778000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      CREATE TABLE IF NOT EXISTS "system"."user_permissions" (
+        "id" SERIAL PRIMARY KEY,
+        "created_by" integer,
+        "updated_by" integer,
+        "deleted_by" integer,
+        "created_at" timestamp with time zone DEFAULT CURRENT_TIMESTAMP,
+        "updated_at" timestamp with time zone DEFAULT CURRENT_TIMESTAMP,
+        "deleted_at" timestamp with time zone,
+        "user_id" integer NOT NULL,
+        "permission_id" integer NOT NULL,
+        "type" varchar(10) NOT NULL DEFAULT 'GRANT',
+        "granted_at" timestamp with time zone DEFAULT CURRENT_TIMESTAMP,
+        "expires_at" timestamp with time zone,
+        CONSTRAINT "fk_user_permissions_user" FOREIGN KEY ("user_id") REFERENCES "system"."users"("id") ON DELETE CASCADE,
+        CONSTRAINT "fk_user_permissions_permission" FOREIGN KEY ("permission_id") REFERENCES "system"."permissions"("id") ON DELETE CASCADE
+      )
+    `);
+
+    // Create unique index
+    await queryRunner.query(`
+      CREATE UNIQUE INDEX IF NOT EXISTS "idx_user_permissions_user_permission" 
+      ON "system"."user_permissions" ("user_id", "permission_id") 
+      WHERE "deleted_at" IS NULL
+    `);
+
+    // Create individual indexes
+    await queryRunner.query(`
+      CREATE INDEX IF NOT EXISTS "idx_user_permissions_user_id" 
+      ON "system"."user_permissions" ("user_id")
+    `);
+
+    await queryRunner.query(`
+      CREATE INDEX IF NOT EXISTS "idx_user_permissions_permission_id" 
+      ON "system"."user_permissions" ("permission_id")
+    `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`DROP TABLE IF EXISTS "system"."user_permissions"`);
+  }
+}

--- a/api.orchestra.com/src/database/seeders/standard-roles.seeder.ts
+++ b/api.orchestra.com/src/database/seeders/standard-roles.seeder.ts
@@ -23,8 +23,10 @@ export const StandardRolesSeeder: Seeder = {
           [role.code],
         );
 
+        let roleId: number;
+
         if (existingRole.length === 0) {
-          await queryRunner.query(
+          const insertResult = await queryRunner.query(
             `INSERT INTO "system"."roles" (
               "name",
               "code",
@@ -33,7 +35,8 @@ export const StandardRolesSeeder: Seeder = {
               "status",
               "created_at",
               "updated_at"
-            ) VALUES ($1, $2, $3, $4, $5, NOW(), NOW())`,
+            ) VALUES ($1, $2, $3, $4, $5, NOW(), NOW())
+            RETURNING id`,
             [
               role.name,
               role.code,
@@ -42,9 +45,48 @@ export const StandardRolesSeeder: Seeder = {
               'ACTIVE',
             ],
           );
+          roleId = insertResult[0].id;
           console.log(`  ✅ Created role: ${role.name}`);
         } else {
-          console.log(`  ⏭️  Role "${role.name}" already exists, skipping...`);
+          roleId = existingRole[0].id;
+          console.log(`  ⏭️  Role "${role.name}" already exists, reusing...`);
+        }
+
+        // Assign all permissions to ADMIN role
+        if (role.code === 'ADMIN') {
+          const permissions = await queryRunner.query(
+            `SELECT id, slug FROM "system"."permissions" WHERE deleted_at IS NULL`,
+          );
+
+          let assignedCount = 0;
+          for (const perm of permissions) {
+            const existing = await queryRunner.query(
+              `SELECT id FROM "system"."role_permissions" 
+               WHERE role_id = $1 AND permission_id = $2`,
+              [roleId, perm.id],
+            );
+
+            if (existing.length === 0) {
+              await queryRunner.query(
+                `INSERT INTO "system"."role_permissions" (
+                  "role_id",
+                  "permission_id",
+                  "created_at",
+                  "updated_at"
+                ) VALUES ($1, $2, NOW(), NOW())`,
+                [roleId, perm.id],
+              );
+              assignedCount++;
+            }
+          }
+
+          if (assignedCount > 0) {
+            console.log(
+              `  ✅ Assigned ${assignedCount} permissions to ADMIN role`,
+            );
+          } else {
+            console.log(`  ⏭️  ADMIN role already has all permissions`);
+          }
         }
       }
     } finally {

--- a/api.orchestra.com/src/decorators/require-permissions.decorator.ts
+++ b/api.orchestra.com/src/decorators/require-permissions.decorator.ts
@@ -1,0 +1,36 @@
+import { SetMetadata } from '@nestjs/common';
+
+/**
+ * Metadata key used to store permission requirements on handlers and classes.
+ */
+export const PERMISSIONS_KEY = 'permissions';
+
+/**
+ * Decorator that sets slug-based permission requirements for controllers or methods.
+ *
+ * Use this decorator to specify which permissions are required to access
+ * a controller method or entire controller. The PermissionsGuard will enforce
+ * these requirements by checking if the authenticated user has the specified permissions.
+ *
+ * @param permissions - One or more permission slugs required (e.g., 'hris.employee.view')
+ * @returns Decorator function that sets metadata on the target
+ *
+ * @example
+ * ```typescript
+ * // Require single permission
+ * @RequirePermissions('hris.employee.view')
+ * @Get()
+ * findAll() {
+ *   return this.employeeService.findAll();
+ * }
+ *
+ * // Require multiple permissions (user must have ALL)
+ * @RequirePermissions('hris.employee.create', 'hris.employee.update')
+ * @Post()
+ * create(@Body() dto: CreateEmployeeDto) {
+ *   return this.employeeService.create(dto);
+ * }
+ * ```
+ */
+export const RequirePermissions = (...permissions: string[]) =>
+  SetMetadata(PERMISSIONS_KEY, permissions);

--- a/api.orchestra.com/src/entities/index.ts
+++ b/api.orchestra.com/src/entities/index.ts
@@ -9,6 +9,7 @@ export * from './system/role.entity';
 export * from './system/permission.entity';
 export * from './system/user-role.entity';
 export * from './system/role-permission.entity';
+export * from './system/user-permission.entity';
 // * Menu
 export * from './system/menu.entity';
 // * Tenant

--- a/api.orchestra.com/src/entities/system/permission.entity.ts
+++ b/api.orchestra.com/src/entities/system/permission.entity.ts
@@ -32,6 +32,9 @@ export class Permission extends CommonEntity {
   @OneToMany('RolePermission', 'permission')
   rolePermissions!: import('./role-permission.entity').RolePermission[];
 
+  @OneToMany('UserPermission', 'permission')
+  userPermissions!: import('./user-permission.entity').UserPermission[];
+
   @OneToMany('Menu', 'permission')
   menus!: import('./menu.entity').Menu[];
 }

--- a/api.orchestra.com/src/entities/system/user-permission.entity.ts
+++ b/api.orchestra.com/src/entities/system/user-permission.entity.ts
@@ -1,0 +1,52 @@
+import { Column, Entity, Index, ManyToOne, JoinColumn } from 'typeorm';
+import { CommonEntity } from '../common.entity';
+
+/**
+ * UserPermission entity for direct user-level permission overrides.
+ *
+ * Allows granting or denying specific permissions to individual users,
+ * overriding their role-based permissions.
+ */
+@Entity({ name: 'user_permissions', schema: 'system' })
+@Index(['userId', 'permissionId'], {
+  unique: true,
+  where: 'deleted_at IS NULL',
+})
+export class UserPermission extends CommonEntity {
+  @Column({ name: 'user_id', type: 'int' })
+  @Index()
+  userId: number;
+
+  @ManyToOne('User', 'userPermissions', { onDelete: 'CASCADE' })
+  @JoinColumn({ name: 'user_id' })
+  user!: import('./user.entity').User;
+
+  @Column({ name: 'permission_id', type: 'int' })
+  @Index()
+  permissionId: number;
+
+  @ManyToOne('Permission', 'userPermissions', { onDelete: 'CASCADE' })
+  @JoinColumn({ name: 'permission_id' })
+  permission!: import('./permission.entity').Permission;
+
+  @Column({
+    type: 'varchar',
+    length: 10,
+    default: 'GRANT',
+  })
+  type: 'GRANT' | 'DENY';
+
+  @Column({
+    name: 'granted_at',
+    type: 'timestamp with time zone',
+    default: () => 'CURRENT_TIMESTAMP',
+  })
+  grantedAt: Date;
+
+  @Column({
+    name: 'expires_at',
+    type: 'timestamp with time zone',
+    nullable: true,
+  })
+  expiresAt?: Date | null;
+}

--- a/api.orchestra.com/src/entities/system/user.entity.ts
+++ b/api.orchestra.com/src/entities/system/user.entity.ts
@@ -57,4 +57,7 @@ export class User extends CommonEntity {
   // Relationships
   @OneToMany('UserRole', 'user')
   userRoles!: import('./user-role.entity').UserRole[];
+
+  @OneToMany('UserPermission', 'user')
+  userPermissions!: import('./user-permission.entity').UserPermission[];
 }

--- a/api.orchestra.com/src/guards/permissions.guard.ts
+++ b/api.orchestra.com/src/guards/permissions.guard.ts
@@ -1,0 +1,84 @@
+import {
+  CanActivate,
+  ExecutionContext,
+  ForbiddenException,
+  Injectable,
+} from '@nestjs/common';
+import { Reflector } from '@nestjs/core';
+import { PERMISSIONS_KEY } from '@/decorators/require-permissions.decorator';
+import { PermissionService } from '@/modules/system/permissions/permission.service';
+
+/**
+ * Guard that enforces slug-based permission access control on protected routes.
+ *
+ * This guard checks if the authenticated user has the required permissions to access
+ * a route decorated with the @RequirePermissions() decorator. It uses the
+ * PermissionService.checkPermission() method to verify access.
+ *
+ * @example
+ * ```typescript
+ * @Controller('employees')
+ * @UseGuards(AuthenticatedGuard, PermissionsGuard)
+ * export class EmployeeController {
+ *   @Get()
+ *   @RequirePermissions('hris.employee.view')
+ *   findAll() { }
+ * }
+ * ```
+ */
+@Injectable()
+export class PermissionsGuard implements CanActivate {
+  constructor(
+    private readonly reflector: Reflector,
+    private readonly permissionService: PermissionService,
+  ) {}
+
+  /**
+   * Checks if the authenticated user has all required permissions for the route.
+   *
+   * @param context - The execution context containing request details
+   * @returns Promise resolving to true if the user has all required permissions
+   * @throws {ForbiddenException} When user lacks required permissions
+   */
+  async canActivate(context: ExecutionContext): Promise<boolean> {
+    const requiredPermissions = this.reflector.getAllAndOverride<string[]>(
+      PERMISSIONS_KEY,
+      [context.getHandler(), context.getClass()],
+    );
+
+    // If no permissions required, allow access
+    if (!requiredPermissions || requiredPermissions.length === 0) {
+      return true;
+    }
+
+    const request = context.switchToHttp().getRequest<{
+      user?: { id: number; isSystemAdmin?: boolean };
+      principal?: { id: number; isSystemAdmin?: boolean };
+    }>();
+    const user = request.user ?? request.principal;
+
+    // If no authenticated user, deny access
+    if (!user) {
+      throw new ForbiddenException('Not authenticated');
+    }
+
+    // System admins bypass permission checks
+    if (user.isSystemAdmin) {
+      return true;
+    }
+
+    // Check each required permission
+    for (const permission of requiredPermissions) {
+      const hasPermission = await this.permissionService.checkPermission(
+        user.id,
+        permission,
+      );
+
+      if (!hasPermission) {
+        throw new ForbiddenException(`Insufficient permission: ${permission}`);
+      }
+    }
+
+    return true;
+  }
+}

--- a/docs/epics/EPIC-RBAC-Implementation-Plan.md
+++ b/docs/epics/EPIC-RBAC-Implementation-Plan.md
@@ -4,7 +4,7 @@
 |-------|-------|
 | **Epic ID** | EPIC-01 |
 | **Epic Name** | Role-Based Access Control & Advanced Session Management |
-| **Status** | 📋 Planned |
+| **Status** | � In Progress |
 | **Priority** | High |
 | **Sprint** | Sprint 1-2 |
 | **Story Points** | 42 |
@@ -24,7 +24,7 @@ Implement a comprehensive RBAC system with flexible role/permission management a
 | Field | Value |
 |-------|-------|
 | **Story ID** | STORY-001 |
-| **Status** | 📋 Planned |
+| **Status** | ✅ Done |
 | **Assignee** | Backend |
 | **Story Points** | 5 |
 
@@ -36,7 +36,7 @@ As a developer, I need a permission system so that access control can be enforce
 | Field | Value |
 |-------|-------|
 | **Sub-Task ID** | BE-001-1 |
-| **Status** | 📋 Planned |
+| **Status** | ✅ Done |
 | **Type** | Backend |
 
 **Changes to Make:**
@@ -85,7 +85,7 @@ export class Permission extends CommonEntity {
 | Field | Value |
 |-------|-------|
 | **Sub-Task ID** | BE-001-2 |
-| **Status** | 📋 Planned |
+| **Status** | ✅ Done |
 | **Type** | Backend |
 
 **Changes to Make:**
@@ -121,7 +121,7 @@ export class Permission extends CommonEntity {
 | Field | Value |
 |-------|-------|
 | **Sub-Task ID** | BE-001-3 |
-| **Status** | 📋 Planned |
+| **Status** | ✅ Done (caching deferred) |
 | **Type** | Backend |
 
 **Changes to Make:**
@@ -146,7 +146,7 @@ export class Permission extends CommonEntity {
 | Field | Value |
 |-------|-------|
 | **Story ID** | STORY-002 |
-| **Status** | 📋 Planned |
+| **Status** | ✅ Done |
 | **Assignee** | Backend |
 | **Story Points** | 5 |
 
@@ -158,7 +158,7 @@ As a developer, I need RBAC junction tables so that roles can be assigned permis
 | Field | Value |
 |-------|-------|
 | **Sub-Task ID** | BE-002-1 |
-| **Status** | 📋 Planned |
+| **Status** | ✅ Done |
 | **Type** | Backend |
 
 **Changes to Make:**
@@ -177,7 +177,7 @@ As a developer, I need RBAC junction tables so that roles can be assigned permis
 | Field | Value |
 |-------|-------|
 | **Sub-Task ID** | BE-002-2 |
-| **Status** | 📋 Planned |
+| **Status** | ✅ Done |
 | **Type** | Backend |
 
 **Changes to Make:**
@@ -196,7 +196,7 @@ As a developer, I need RBAC junction tables so that roles can be assigned permis
 | Field | Value |
 |-------|-------|
 | **Story ID** | STORY-003 |
-| **Status** | 📋 Planned |
+| **Status** | ✅ Done |
 | **Assignee** | Backend |
 | **Story Points** | 5 |
 
@@ -208,7 +208,7 @@ As a developer, I need guards and decorators to enforce permissions on routes.
 | Field | Value |
 |-------|-------|
 | **Sub-Task ID** | BE-003-1 |
-| **Status** | 📋 Planned |
+| **Status** | ✅ Done |
 | **Type** | Backend |
 
 **Changes to Make:**


### PR DESCRIPTION
## Description

Implements STORY-002 (RBAC Entities) and STORY-003 (Permission Guards) from EPIC-01.

### What's New

**STORY-002: RBAC Entities & Role-Permission Linking**
- [UserPermission](cci:2://file:///c:/Users/ROMEL/Desktop/Romel%20Documents/development/Personal%20Passion/erp-orchestra/api.orchestra.com/src/entities/system/user-permission.entity.ts:9:0-51:1) entity for direct user-level grants/denies
- Updated [standard-roles.seeder.ts](cci:7://file:///c:/Users/ROMEL/Desktop/Romel%20Documents/development/Personal%20Passion/erp-orchestra/api.orchestra.com/src/database/seeders/standard-roles.seeder.ts:0:0-0:0) - ADMIN role now gets all 17 permissions
- Migration for `user_permissions` table

**STORY-003: Permission Guards & Decorators**
- `@RequirePermissions('hris.employee.view')` decorator (slug-based)
- [PermissionsGuard](cci:2://file:///c:/Users/ROMEL/Desktop/Romel%20Documents/development/Personal%20Passion/erp-orchestra/api.orchestra.com/src/guards/permissions.guard.ts:28:0-83:1) with [checkPermission()](cci:1://file:///c:/Users/ROMEL/Desktop/Romel%20Documents/development/Personal%20Passion/erp-orchestra/api.orchestra.com/src/modules/system/permissions/permission.controller.ts:74:2-83:3) integration
- System admin bypass support

### Usage
```typescript
@UseGuards(AuthenticatedGuard, PermissionsGuard)
@RequirePermissions('hris.employee.view')
@Get()
findAll() { }