### PR TITLE
feat(api): role management API with CRUD and permission assignment

### DIFF
--- a/api.orchestra.com/src/modules/system/roles/dto/assign-permissions.dto.ts
+++ b/api.orchestra.com/src/modules/system/roles/dto/assign-permissions.dto.ts
@@ -1,0 +1,17 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsArray, IsInt, ArrayMinSize } from 'class-validator';
+
+/**
+ * DTO for assigning or removing permissions from a role.
+ */
+export class AssignPermissionsDto {
+  @ApiProperty({
+    example: [1, 2, 3],
+    description: 'Array of permission IDs to assign to the role',
+    type: [Number],
+  })
+  @IsArray()
+  @ArrayMinSize(1)
+  @IsInt({ each: true })
+  permissionIds: number[];
+}

--- a/api.orchestra.com/src/modules/system/roles/dto/create-role.dto.ts
+++ b/api.orchestra.com/src/modules/system/roles/dto/create-role.dto.ts
@@ -1,0 +1,34 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsString, IsNotEmpty, IsOptional, MaxLength } from 'class-validator';
+
+/**
+ * DTO for creating a new role.
+ */
+export class CreateRoleDto {
+  @ApiProperty({
+    example: 'HR Manager',
+    description: 'Display name for the role',
+  })
+  @IsString()
+  @IsNotEmpty()
+  @MaxLength(100)
+  name: string;
+
+  @ApiProperty({
+    example: 'HR_MGR',
+    description: 'Unique code identifier for the role',
+  })
+  @IsString()
+  @IsNotEmpty()
+  @MaxLength(50)
+  code: string;
+
+  @ApiProperty({
+    example: 'Manages HR department employees and leave requests',
+    description: 'Optional description of the role',
+    required: false,
+  })
+  @IsString()
+  @IsOptional()
+  description?: string;
+}

--- a/api.orchestra.com/src/modules/system/roles/dto/update-role.dto.ts
+++ b/api.orchestra.com/src/modules/system/roles/dto/update-role.dto.ts
@@ -1,0 +1,8 @@
+import { PartialType } from '@nestjs/swagger';
+import { CreateRoleDto } from './create-role.dto';
+
+/**
+ * DTO for updating an existing role.
+ * All fields are optional.
+ */
+export class UpdateRoleDto extends PartialType(CreateRoleDto) {}

--- a/api.orchestra.com/src/modules/system/roles/role.controller.ts
+++ b/api.orchestra.com/src/modules/system/roles/role.controller.ts
@@ -1,24 +1,145 @@
-import { Controller, Get, UseGuards } from '@nestjs/common';
 import {
-  ApiBearerAuth,
+  Controller,
+  Get,
+  Post,
+  Patch,
+  Delete,
+  Body,
+  Param,
+  ParseIntPipe,
+  UseGuards,
+} from '@nestjs/common';
+import {
+  ApiTags,
   ApiOperation,
   ApiResponse,
-  ApiTags,
+  ApiBearerAuth,
+  ApiBody,
+  ApiParam,
 } from '@nestjs/swagger';
-import { AuthenticatedGuard } from '../../../guards/authenticated.guard';
 import { RoleService } from './role.service';
+import { CreateRoleDto } from './dto/create-role.dto';
+import { UpdateRoleDto } from './dto/update-role.dto';
+import { AssignPermissionsDto } from './dto/assign-permissions.dto';
+import { AuthenticatedGuard } from '@/guards/authenticated.guard';
+import { RolesGuard } from '@/guards/roles.guard';
+import { Roles } from '@/decorators/roles.decorator';
+import { Role } from '@/entities/system/role.entity';
 
+/**
+ * Controller for managing Role resources.
+ *
+ * Provides CRUD endpoints and permission assignment.
+ * Access is restricted to users with ADMIN role.
+ */
 @ApiTags('Roles')
-@Controller('roles')
-@UseGuards(AuthenticatedGuard)
 @ApiBearerAuth()
+@UseGuards(AuthenticatedGuard, RolesGuard)
+@Roles('ADMIN')
+@Controller('system/roles')
 export class RoleController {
   constructor(private readonly roleService: RoleService) {}
 
+  /**
+   * Lists all roles.
+   */
   @Get()
   @ApiOperation({ summary: 'List all roles' })
-  @ApiResponse({ status: 200, description: 'Return all roles.' })
-  async findAll() {
+  @ApiResponse({ status: 200, description: 'Returns all roles.' })
+  findAll(): Promise<Role[]> {
     return this.roleService.findAll();
+  }
+
+  /**
+   * Gets a role by ID with its permissions.
+   */
+  @Get(':id')
+  @ApiOperation({ summary: 'Get role by ID with permissions' })
+  @ApiParam({ name: 'id', type: Number })
+  @ApiResponse({
+    status: 200,
+    description: 'Returns the role with permissions.',
+  })
+  @ApiResponse({ status: 404, description: 'Role not found.' })
+  findOne(@Param('id', ParseIntPipe) id: number): Promise<Role> {
+    return this.roleService.findOne(id);
+  }
+
+  /**
+   * Creates a new role.
+   */
+  @Post()
+  @ApiOperation({ summary: 'Create a new role' })
+  @ApiBody({ type: CreateRoleDto })
+  @ApiResponse({ status: 201, description: 'Role created successfully.' })
+  @ApiResponse({ status: 400, description: 'Bad Request.' })
+  create(@Body() dto: CreateRoleDto): Promise<Role> {
+    return this.roleService.create(dto);
+  }
+
+  /**
+   * Updates an existing role.
+   */
+  @Patch(':id')
+  @ApiOperation({ summary: 'Update a role' })
+  @ApiParam({ name: 'id', type: Number })
+  @ApiBody({ type: UpdateRoleDto })
+  @ApiResponse({ status: 200, description: 'Role updated successfully.' })
+  @ApiResponse({ status: 404, description: 'Role not found.' })
+  update(
+    @Param('id', ParseIntPipe) id: number,
+    @Body() dto: UpdateRoleDto,
+  ): Promise<Role> {
+    return this.roleService.update(id, dto);
+  }
+
+  /**
+   * Soft deletes a role.
+   */
+  @Delete(':id')
+  @ApiOperation({ summary: 'Delete a role' })
+  @ApiParam({ name: 'id', type: Number })
+  @ApiResponse({ status: 200, description: 'Role deleted successfully.' })
+  @ApiResponse({ status: 404, description: 'Role not found.' })
+  remove(@Param('id', ParseIntPipe) id: number): Promise<void> {
+    return this.roleService.remove(id);
+  }
+
+  /**
+   * Assigns permissions to a role.
+   */
+  @Post(':id/permissions')
+  @ApiOperation({ summary: 'Assign permissions to a role' })
+  @ApiParam({ name: 'id', type: Number })
+  @ApiBody({ type: AssignPermissionsDto })
+  @ApiResponse({
+    status: 200,
+    description: 'Permissions assigned successfully.',
+  })
+  @ApiResponse({ status: 404, description: 'Role or permission not found.' })
+  assignPermissions(
+    @Param('id', ParseIntPipe) id: number,
+    @Body() dto: AssignPermissionsDto,
+  ): Promise<Role> {
+    return this.roleService.assignPermissions(id, dto.permissionIds);
+  }
+
+  /**
+   * Removes permissions from a role.
+   */
+  @Delete(':id/permissions')
+  @ApiOperation({ summary: 'Remove permissions from a role' })
+  @ApiParam({ name: 'id', type: Number })
+  @ApiBody({ type: AssignPermissionsDto })
+  @ApiResponse({
+    status: 200,
+    description: 'Permissions removed successfully.',
+  })
+  @ApiResponse({ status: 404, description: 'Role not found.' })
+  removePermissions(
+    @Param('id', ParseIntPipe) id: number,
+    @Body() dto: AssignPermissionsDto,
+  ): Promise<Role> {
+    return this.roleService.removePermissions(id, dto.permissionIds);
   }
 }

--- a/api.orchestra.com/src/modules/system/roles/role.module.ts
+++ b/api.orchestra.com/src/modules/system/roles/role.module.ts
@@ -2,10 +2,12 @@ import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { RoleController } from './role.controller';
 import { RoleService } from './role.service';
-import { Role } from '../../../entities/system/role.entity';
+import { Role } from '@/entities/system/role.entity';
+import { RolePermission } from '@/entities/system/role-permission.entity';
+import { Permission } from '@/entities/system/permission.entity';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([Role])],
+  imports: [TypeOrmModule.forFeature([Role, RolePermission, Permission])],
   controllers: [RoleController],
   providers: [RoleService],
   exports: [RoleService],

--- a/api.orchestra.com/src/modules/system/roles/role.service.ts
+++ b/api.orchestra.com/src/modules/system/roles/role.service.ts
@@ -1,16 +1,134 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable, NotFoundException } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
-import { Repository } from 'typeorm';
-import { Role } from '../../../entities/system/role.entity';
+import { Repository, In } from 'typeorm';
+import { Role } from '@/entities/system/role.entity';
+import { RolePermission } from '@/entities/system/role-permission.entity';
+import { Permission } from '@/entities/system/permission.entity';
+import { CreateRoleDto } from './dto/create-role.dto';
+import { UpdateRoleDto } from './dto/update-role.dto';
 
+/**
+ * Service responsible for role management and permission assignment.
+ */
 @Injectable()
 export class RoleService {
   constructor(
     @InjectRepository(Role)
     private readonly roleRepository: Repository<Role>,
+    @InjectRepository(RolePermission)
+    private readonly rolePermissionRepository: Repository<RolePermission>,
+    @InjectRepository(Permission)
+    private readonly permissionRepository: Repository<Permission>,
   ) {}
 
-  async findAll() {
-    return this.roleRepository.find();
+  /**
+   * Retrieves all roles.
+   */
+  async findAll(): Promise<Role[]> {
+    return this.roleRepository.find({
+      order: { name: 'ASC' },
+    });
+  }
+
+  /**
+   * Retrieves a role by ID with its assigned permissions.
+   */
+  async findOne(id: number): Promise<Role> {
+    const role = await this.roleRepository.findOne({
+      where: { id },
+      relations: ['rolePermissions', 'rolePermissions.permission'],
+    });
+
+    if (!role) {
+      throw new NotFoundException(`Role with ID ${id} not found`);
+    }
+
+    return role;
+  }
+
+  /**
+   * Creates a new role.
+   */
+  async create(dto: CreateRoleDto): Promise<Role> {
+    const role = this.roleRepository.create(dto);
+    return this.roleRepository.save(role);
+  }
+
+  /**
+   * Updates an existing role.
+   */
+  async update(id: number, dto: UpdateRoleDto): Promise<Role> {
+    const role = await this.findOne(id);
+    Object.assign(role, dto);
+    return this.roleRepository.save(role);
+  }
+
+  /**
+   * Soft deletes a role.
+   */
+  async remove(id: number): Promise<void> {
+    const role = await this.findOne(id);
+    await this.roleRepository.softRemove(role);
+  }
+
+  /**
+   * Assigns permissions to a role.
+   *
+   * @param roleId - The role ID
+   * @param permissionIds - Array of permission IDs to assign
+   * @returns The updated role with permissions
+   */
+  async assignPermissions(
+    roleId: number,
+    permissionIds: number[],
+  ): Promise<Role> {
+    await this.findOne(roleId); // Validate role exists
+
+    // Validate permissions exist
+    const permissions = await this.permissionRepository.find({
+      where: { id: In(permissionIds) },
+    });
+
+    if (permissions.length !== permissionIds.length) {
+      throw new NotFoundException('One or more permissions not found');
+    }
+
+    // Create role-permission links (ignore duplicates)
+    for (const permissionId of permissionIds) {
+      const existing = await this.rolePermissionRepository.findOne({
+        where: { roleId, permissionId },
+      });
+
+      if (!existing) {
+        const rolePermission = this.rolePermissionRepository.create({
+          roleId,
+          permissionId,
+        });
+        await this.rolePermissionRepository.save(rolePermission);
+      }
+    }
+
+    return this.findOne(roleId);
+  }
+
+  /**
+   * Removes permissions from a role.
+   *
+   * @param roleId - The role ID
+   * @param permissionIds - Array of permission IDs to remove
+   * @returns The updated role with remaining permissions
+   */
+  async removePermissions(
+    roleId: number,
+    permissionIds: number[],
+  ): Promise<Role> {
+    await this.findOne(roleId); // Verify role exists
+
+    await this.rolePermissionRepository.delete({
+      roleId,
+      permissionId: In(permissionIds),
+    });
+
+    return this.findOne(roleId);
   }
 }

--- a/api.orchestra.com/src/modules/system/roles/roles.endpoints.http
+++ b/api.orchestra.com/src/modules/system/roles/roles.endpoints.http
@@ -1,0 +1,70 @@
+### Login (Establish Session)
+# @name adminLogin
+POST {{API_BASE_URL}}/v1/auth/login
+Content-Type: application/json
+
+{
+    "email": "{{TEST_USERNAME}}",
+    "password": "{{TEST_USER_PASSWORD}}"
+}
+
+###
+
+### List All Roles
+GET {{API_BASE_URL}}/v1/system/roles
+Content-Type: application/json
+
+###
+
+### Get Role by ID (with permissions)
+@roleId = 1
+GET {{API_BASE_URL}}/v1/system/roles/{{roleId}}
+Content-Type: application/json
+
+###
+
+### Create New Role
+POST {{API_BASE_URL}}/v1/system/roles
+Content-Type: application/json
+
+{
+    "name": "HR Manager",
+    "code": "HR_MGR",
+    "description": "Manages HR department operations"
+}
+
+###
+
+### Update Role
+PATCH {{API_BASE_URL}}/v1/system/roles/{{roleId}}
+Content-Type: application/json
+
+{
+    "description": "Updated description"
+}
+
+###
+
+### Assign Permissions to Role
+POST {{API_BASE_URL}}/v1/system/roles/{{roleId}}/permissions
+Content-Type: application/json
+
+{
+    "permissionIds": [1, 2, 3]
+}
+
+###
+
+### Remove Permissions from Role
+DELETE {{API_BASE_URL}}/v1/system/roles/{{roleId}}/permissions
+Content-Type: application/json
+
+{
+    "permissionIds": [3]
+}
+
+###
+
+### Delete Role (Soft Delete)
+DELETE {{API_BASE_URL}}/v1/system/roles/{{roleId}}
+Content-Type: application/json

--- a/docs/epics/EPIC-RBAC-Implementation-Plan.md
+++ b/docs/epics/EPIC-RBAC-Implementation-Plan.md
@@ -229,7 +229,7 @@ As a developer, I need guards and decorators to enforce permissions on routes.
 | Field | Value |
 |-------|-------|
 | **Story ID** | STORY-004 |
-| **Status** | 📋 Planned |
+| **Status** | ✅ Done |
 | **Assignee** | Backend |
 | **Story Points** | 8 |
 
@@ -241,7 +241,7 @@ As an admin, I want to manage roles and assign permissions dynamically.
 | Field | Value |
 |-------|-------|
 | **Sub-Task ID** | BE-004-1 |
-| **Status** | 📋 Planned |
+| **Status** | ✅ Done |
 | **Type** | Backend |
 
 **Changes to Make:**


### PR DESCRIPTION
## Description

Implements **STORY-004: Role Management API** to allow administrators to manage roles and dynamically assign permissions.

### What's New

- **Role CRUD**: Create, Read, Update, Delete roles via API.
- **Permission Assignment**: 
  - `POST /system/roles/:id/permissions` - Assign permissions to a role.
  - `DELETE /system/roles/:id/permissions` - Remove permissions.
- **DTOs**: Validated DTOs for creating roles and assigning permission IDs.

### Role Controller Endpoints

| Method | Endpoint | Description |
|--------|----------|-------------|
| `GET` | `/system/roles` | List all roles |
| `GET` | `/system/roles/:id` | Get role details with permissions |
| `POST` | `/system/roles` | Create new role |
| `PATCH` | `/system/roles/:id` | Update role details |
| `DELETE` | `/system/roles/:id` | Soft delete role |

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## Checklist

- [x] RoleService implementation
- [x] RoleController implementation with `@Roles('ADMIN')` guard
- [x] DTO validation
- [x] HTTP endpoint tests