### PR TITLE
feat(portal): implement user management with decoupled RBAC

### DIFF
--- a/api.orchestra.com/src/modules/system/auth/providers/auth.service.ts
+++ b/api.orchestra.com/src/modules/system/auth/providers/auth.service.ts
@@ -90,7 +90,7 @@ export class AuthService {
       avatarUrl: user.avatarUrl,
       tenantId: user.tenantId,
       isSystemAdmin: user.isSystemAdmin,
-      roles: user.userRoles?.map((ur) => ur.role?.name).filter(Boolean) ?? [],
+      roles: user.userRoles?.map((ur) => ur.role?.code).filter(Boolean) ?? [],
       permissions: Array.from(permissions),
     };
   }

--- a/api.orchestra.com/src/modules/system/roles/dto/create-role.dto.ts
+++ b/api.orchestra.com/src/modules/system/roles/dto/create-role.dto.ts
@@ -1,5 +1,12 @@
 import { ApiProperty } from '@nestjs/swagger';
-import { IsString, IsNotEmpty, IsOptional, MaxLength } from 'class-validator';
+import {
+  IsString,
+  IsNotEmpty,
+  IsOptional,
+  MaxLength,
+  IsArray,
+  IsInt,
+} from 'class-validator';
 
 /**
  * DTO for creating a new role.
@@ -28,7 +35,23 @@ export class CreateRoleDto {
     description: 'Optional description of the role',
     required: false,
   })
+  @ApiProperty({
+    example: 'Manages HR department employees and leave requests',
+    description: 'Optional description of the role',
+    required: false,
+  })
   @IsString()
   @IsOptional()
   description?: string;
+
+  @ApiProperty({
+    example: [1, 2, 3],
+    description: 'List of permission IDs to assign to the role upon creation',
+    required: false,
+    type: [Number],
+  })
+  @IsOptional()
+  @IsArray()
+  @IsInt({ each: true })
+  permissionIds?: number[];
 }

--- a/api.orchestra.com/src/modules/system/roles/role.service.ts
+++ b/api.orchestra.com/src/modules/system/roles/role.service.ts
@@ -77,7 +77,17 @@ export class RoleService {
       tenantId,
       isSystemRole: false, // Custom roles are never system roles
     });
-    return this.roleRepository.save(role);
+
+    const savedRole = await this.roleRepository.save(role);
+
+    // If permissions are provided, assign them immediately
+    if (dto.permissionIds && dto.permissionIds.length > 0) {
+      await this.assignPermissions(savedRole.id, dto.permissionIds, tenantId);
+      // Reload role with permissions
+      return this.findOne(savedRole.id, tenantId);
+    }
+
+    return savedRole;
   }
 
   /**

--- a/api.orchestra.com/src/modules/system/users/dto/create-tenant-user.dto.ts
+++ b/api.orchestra.com/src/modules/system/users/dto/create-tenant-user.dto.ts
@@ -5,8 +5,6 @@ import {
   MinLength,
   IsEnum,
   IsOptional,
-  IsArray,
-  IsInt,
 } from 'class-validator';
 import { ApiProperty } from '@nestjs/swagger';
 import { Status } from '@/types/enums';
@@ -47,9 +45,4 @@ export class CreateTenantUserDto {
   isTenantAdmin?: boolean;
 
   // Role IDs to assign to this user
-  @ApiProperty({ example: [1, 2], type: [Number], required: false })
-  @IsOptional()
-  @IsArray()
-  @IsInt({ each: true })
-  roleIds?: number[];
 }

--- a/api.orchestra.com/src/modules/system/users/user.module.ts
+++ b/api.orchestra.com/src/modules/system/users/user.module.ts
@@ -4,11 +4,9 @@ import { UserController } from './user.controller';
 import { UserService } from './user.service';
 import { User } from '../../../entities/system/user.entity';
 import { Tenant } from '../../../entities/system/tenant.entity';
-import { Role } from '../../../entities/system/role.entity';
-import { UserRole } from '../../../entities/system/user-role.entity';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([User, Tenant, Role, UserRole])],
+  imports: [TypeOrmModule.forFeature([User, Tenant])],
   controllers: [UserController],
   providers: [UserService],
   exports: [UserService],

--- a/api.orchestra.com/src/modules/system/users/users.endpoints.http
+++ b/api.orchestra.com/src/modules/system/users/users.endpoints.http
@@ -1,0 +1,48 @@
+### Login (Establish Session)
+# @name adminLogin
+POST {{API_BASE_URL}}/v1/auth/login
+Content-Type: application/json
+
+{
+    "email": "{{TEST_USERNAME}}",
+    "password": "{{TEST_USER_PASSWORD}}"
+}
+
+### List Users (Current Tenant)
+GET {{API_BASE_URL}}/v1/users?limit=10
+Content-Type: application/json
+Authorization: Bearer {{adminLogin.response.body.accessToken}}
+
+### Create User (Current Tenant)
+# @name createUser
+POST {{API_BASE_URL}}/v1/users
+Content-Type: application/json
+Authorization: Bearer {{adminLogin.response.body.accessToken}}
+
+{
+    "email": "newuser@example.com",
+    "password": "password123",
+    "firstName": "New",
+    "lastName": "User",
+    "isTenantAdmin": false
+}
+
+### Get User by ID
+@userId = {{createUser.response.body.id}}
+GET {{API_BASE_URL}}/v1/users/{{userId}}
+Content-Type: application/json
+Authorization: Bearer {{adminLogin.response.body.accessToken}}
+
+### Update User
+PATCH {{API_BASE_URL}}/v1/users/{{userId}}
+Content-Type: application/json
+Authorization: Bearer {{adminLogin.response.body.accessToken}}
+
+{
+    "firstName": "Updated Name"
+}
+
+### Delete User
+DELETE {{API_BASE_URL}}/v1/users/{{userId}}
+Content-Type: application/json
+Authorization: Bearer {{adminLogin.response.body.accessToken}}

--- a/portal.orchestra.com/app/layout.tsx
+++ b/portal.orchestra.com/app/layout.tsx
@@ -3,6 +3,7 @@ import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
 
 import { Providers } from "@/components/Providers";
+import { Toaster } from "@/components/ui/sonner";
 
 const geistSans = Geist({
   variable: "--font-geist-sans",
@@ -28,11 +29,14 @@ export default function RootLayout({
     <html lang="en">
       <body
         className={`${geistSans.variable} ${geistMono.variable} antialiased`}
+        suppressHydrationWarning
       >
         <Providers>
           {children}
+          <Toaster />
         </Providers>
       </body>
     </html>
   );
 }
+

--- a/portal.orchestra.com/app/users/form-fields.ts
+++ b/portal.orchestra.com/app/users/form-fields.ts
@@ -1,20 +1,20 @@
 import { FormField } from "@/components/entity-manager";
 
-// NOTE: The role options will typically be fetched dynamically. 
-// For now, we use placeholders.
-const roleOptions = [
-  { label: "Administrator", value: "1" },
-  { label: "Editor", value: "2" },
-  { label: "Viewer", value: "3" },
-];
-
 export const userFormFields: FormField[] = [
   {
-    name: "name",
-    label: "Full Name",
+    name: "firstName",
+    label: "First Name",
     type: "text",
     required: true,
-    placeholder: "e.g., John Doe",
+    placeholder: "e.g., John",
+    width: "half",
+  },
+  {
+    name: "lastName",
+    label: "Last Name",
+    type: "text",
+    required: true,
+    placeholder: "e.g., Doe",
     width: "half",
   },
   {
@@ -23,37 +23,29 @@ export const userFormFields: FormField[] = [
     type: "email",
     required: true,
     placeholder: "e.g., john.doe@example.com",
-    width: "half",
+    width: "full",
   },
   {
     name: "password",
     label: "Password",
     type: "password",
     required: true,
-    placeholder: "New password (only on create)",
-    description: "Required for new users. Leave blank to keep current password on edit.",
-    width: "half",
+    placeholder: "Enter password",
+    width: "full",
+    defaultValue: "password123",
+    description: "Default password is 'password123'",
   },
-  {
-    name: "roleId",
-    label: "Role",
-    type: "select",
-    required: true,
-    options: roleOptions,
-    width: "half",
-  },
-  // Status field is managed internally or set by the backend, 
-  // but we can add it for completeness if needed for edits.
   {
     name: "status",
     label: "Status",
     type: "select",
     required: true,
     options: [
-      { label: "Active", value: "active" },
-      { label: "Inactive", value: "inactive" },
+      { label: "Active", value: "ACTIVE" },
+      { label: "Inactive", value: "INACTIVE" },
     ],
-    defaultValue: "active",
-    width: "half",
+    defaultValue: "ACTIVE",
+    width: "full",
   },
 ];
+

--- a/portal.orchestra.com/components/entity-manager/types.ts
+++ b/portal.orchestra.com/components/entity-manager/types.ts
@@ -1,7 +1,7 @@
 import { Column } from "@/components/ui/data-table";
 import { ReactNode } from "react";
 
-export type FormFieldType = "text" | "email" | "number" | "select" | "textarea" | "date";
+export type FormFieldType = "text" | "email" | "number" | "select" | "textarea" | "date" | 'password';
 
 export interface FormFieldOption {
   label: string;

--- a/portal.orchestra.com/components/ui/sonner.tsx
+++ b/portal.orchestra.com/components/ui/sonner.tsx
@@ -1,0 +1,40 @@
+"use client"
+
+import {
+  CircleCheckIcon,
+  InfoIcon,
+  Loader2Icon,
+  OctagonXIcon,
+  TriangleAlertIcon,
+} from "lucide-react"
+import { useTheme } from "next-themes"
+import { Toaster as Sonner, type ToasterProps } from "sonner"
+
+const Toaster = ({ ...props }: ToasterProps) => {
+  const { theme = "system" } = useTheme()
+
+  return (
+    <Sonner
+      theme={theme as ToasterProps["theme"]}
+      className="toaster group"
+      icons={{
+        success: <CircleCheckIcon className="size-4" />,
+        info: <InfoIcon className="size-4" />,
+        warning: <TriangleAlertIcon className="size-4" />,
+        error: <OctagonXIcon className="size-4" />,
+        loading: <Loader2Icon className="size-4 animate-spin" />,
+      }}
+      style={
+        {
+          "--normal-bg": "var(--popover)",
+          "--normal-text": "var(--popover-foreground)",
+          "--normal-border": "var(--border)",
+          "--border-radius": "var(--radius)",
+        } as React.CSSProperties
+      }
+      {...props}
+    />
+  )
+}
+
+export { Toaster }

--- a/portal.orchestra.com/lib/toast.ts
+++ b/portal.orchestra.com/lib/toast.ts
@@ -1,0 +1,28 @@
+import { toast as sonnerToast } from "sonner";
+
+export const toast = {
+  success: (message: string) => {
+    sonnerToast.success(message);
+  },
+  error: (message: string | any) => {
+    let errorMessage = "An unexpected error occurred.";
+
+    if (typeof message === "string") {
+      errorMessage = message;
+    } else if (message?.data?.message) {
+      // API error response structure: { data: { message: "..." } }
+      errorMessage = message.data.message;
+    } else if (message?.message) {
+      // Generic Error object
+      errorMessage = message.message;
+    }
+
+    sonnerToast.error(errorMessage);
+  },
+  info: (message: string) => {
+    sonnerToast.info(message);
+  },
+  warning: (message: string) => {
+    sonnerToast.warning(message);
+  },
+};


### PR DESCRIPTION
## Summary
Implements user management functionality in the portal application with proper RBAC integration and decouples role assignment from user CRUD operations.

## Changes

### Portal (Frontend)
- **Users API Slice**: Added RTK Query API for user CRUD operations with proper paginated response handling ([transformResponse](cci:1://file:///c:/Users/ROMEL/Desktop/Romel%20Documents/development/Personal%20Passion/erp-orchestra/portal.orchestra.com/store/api/usersApi.ts:39:6-39:77))
- **User Form Fields**: Created form configuration matching backend DTO structure (firstName, lastName, email, password, status)
- **Toast Notifications**: Added Sonner toast component and utility wrapper for success/error feedback
- **Entity Manager Types**: Updated types to support password field type

### API (Backend)
- **Role Creation Enhancement**: [CreateRoleDto](cci:2://file:///c:/Users/ROMEL/Desktop/Romel%20Documents/development/Personal%20Passion/erp-orchestra/api.orchestra.com/src/modules/system/roles/dto/create-role.dto.ts:6:0-49:1) now accepts optional `permissionIds` array for single-step role+permission setup
- **RolesGuard Fix**: Now correctly extracts role codes from nested `userRoles[].role.code` structure (from session deserialization)
- **AuthService Fix**: Returns role `code` instead of `name` in login response to match RolesGuard expectations
- **User Module Decoupling**: Removed `roleIds` handling from UserService - role assignment is now exclusively handled through the Roles module
- **HTTP Test Endpoints**: Added [users.endpoints.http](cci:7://file:///c:/Users/ROMEL/Desktop/Romel%20Documents/development/Personal%20Passion/erp-orchestra/api.orchestra.com/src/modules/system/users/users.endpoints.http:0:0-0:0) for API testing

## Breaking Changes
- User creation/update no longer accepts `roleIds` - use the Roles module endpoints to assign roles to users

## Testing
- [x] Create a new user via portal
- [x] Verify toast notifications appear on success/error
- [] Create a role with permissions in single request
- [ ] Verify role-based access control works after re-login

## Related
- Roles module: `POST /system/roles/:id/permissions` for role-permission assignment