### PR TITLE
feat(rbac): implement role and user management ui with backend integr…

### DIFF
--- a/api.orchestra.com/src/modules/system/roles/dto/assign-users.dto.ts
+++ b/api.orchestra.com/src/modules/system/roles/dto/assign-users.dto.ts
@@ -1,0 +1,17 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsArray, IsInt, ArrayMinSize } from 'class-validator';
+
+/**
+ * DTO for assigning users to a role.
+ */
+export class AssignUsersDto {
+  @ApiProperty({
+    description: 'Array of user IDs to assign to the role',
+    example: [1, 2, 3],
+    type: [Number],
+  })
+  @IsArray()
+  @ArrayMinSize(1)
+  @IsInt({ each: true })
+  userIds: number[];
+}

--- a/api.orchestra.com/src/modules/system/roles/role.controller.ts
+++ b/api.orchestra.com/src/modules/system/roles/role.controller.ts
@@ -23,6 +23,7 @@ import { RoleService } from './role.service';
 import { CreateRoleDto } from './dto/create-role.dto';
 import { UpdateRoleDto } from './dto/update-role.dto';
 import { AssignPermissionsDto } from './dto/assign-permissions.dto';
+import { AssignUsersDto } from './dto/assign-users.dto';
 import { AuthenticatedGuard } from '@/guards/authenticated.guard';
 import { RolesGuard } from '@/guards/roles.guard';
 import { Roles } from '@/decorators/roles.decorator';
@@ -166,6 +167,54 @@ export class RoleController {
     return this.roleService.removePermissions(
       id,
       dto.permissionIds,
+      req.user.tenantId ?? undefined,
+    );
+  }
+
+  /**
+   * Assigns users to a role.
+   */
+  @Post(':id/users')
+  @ApiOperation({ summary: 'Assign users to a role' })
+  @ApiParam({ name: 'id', type: Number })
+  @ApiBody({ type: AssignUsersDto })
+  @ApiResponse({
+    status: 200,
+    description: 'Users assigned successfully.',
+  })
+  @ApiResponse({ status: 404, description: 'Role not found.' })
+  assignUsers(
+    @Param('id', ParseIntPipe) id: number,
+    @Body() dto: AssignUsersDto,
+    @Req() req: AuthenticatedRequest,
+  ): Promise<Role> {
+    return this.roleService.assignUsers(
+      id,
+      dto.userIds,
+      req.user.tenantId ?? undefined,
+    );
+  }
+
+  /**
+   * Removes a user from a role.
+   */
+  @Delete(':id/users/:userId')
+  @ApiOperation({ summary: 'Remove a user from a role' })
+  @ApiParam({ name: 'id', type: Number })
+  @ApiParam({ name: 'userId', type: Number })
+  @ApiResponse({
+    status: 200,
+    description: 'User removed successfully.',
+  })
+  @ApiResponse({ status: 404, description: 'Role not found.' })
+  removeUser(
+    @Param('id', ParseIntPipe) id: number,
+    @Param('userId', ParseIntPipe) userId: number,
+    @Req() req: AuthenticatedRequest,
+  ): Promise<void> {
+    return this.roleService.removeUser(
+      id,
+      userId,
       req.user.tenantId ?? undefined,
     );
   }

--- a/api.orchestra.com/src/modules/system/roles/role.service.ts
+++ b/api.orchestra.com/src/modules/system/roles/role.service.ts
@@ -174,4 +174,58 @@ export class RoleService {
 
     return this.findOne(roleId, tenantId);
   }
+
+  /**
+   * Assigns users to a role.
+   *
+   * @param roleId - The role ID
+   * @param userIds - Array of user IDs to assign
+   * @param tenantId - Optional tenant ID for scoping
+   * @returns The updated role
+   */
+  async assignUsers(
+    roleId: number,
+    userIds: number[],
+    tenantId?: number,
+  ): Promise<Role> {
+    await this.findOne(roleId, tenantId); // Validate role exists and belongs to tenant
+
+    // Create user-role links (ignore duplicates)
+    for (const userId of userIds) {
+      const existing = await this.roleRepository.manager
+        .getRepository('UserRole')
+        .findOne({
+          where: { userId, roleId },
+        });
+
+      if (!existing) {
+        await this.roleRepository.manager
+          .getRepository('UserRole')
+          .save({ userId, roleId });
+      }
+    }
+
+    return this.findOne(roleId, tenantId);
+  }
+
+  /**
+   * Removes a user from a role.
+   *
+   * @param roleId - The role ID
+   * @param userId - The user ID to remove
+   * @param tenantId - Optional tenant ID for scoping
+   * @returns The updated role
+   */
+  async removeUser(
+    roleId: number,
+    userId: number,
+    tenantId?: number,
+  ): Promise<void> {
+    await this.findOne(roleId, tenantId); // Verify role exists and belongs to tenant
+
+    await this.roleRepository.manager.getRepository('UserRole').delete({
+      roleId,
+      userId,
+    });
+  }
 }

--- a/portal.orchestra.com/app/roles/column.tsx
+++ b/portal.orchestra.com/app/roles/column.tsx
@@ -11,9 +11,21 @@ export const columns: Column<any>[] = [
         <div className="h-8 w-8 rounded-lg bg-purple-100 flex items-center justify-center">
           <Shield className="h-4 w-4 text-purple-600" />
         </div>
-        <span className="font-medium">{item.name}</span>
+        <div className="flex flex-col">
+          <span className="font-medium">{item.name}</span>
+          {item.isSystemRole && (
+            <Badge variant="secondary" className="w-fit text-xs">
+              System Role
+            </Badge>
+          )}
+        </div>
       </div>
     ),
+  },
+  {
+    header: "Code",
+    accessorKey: "code",
+    cell: (item) => <span className="text-sm font-mono text-gray-600">{item.code}</span>,
   },
   {
     header: "Description",

--- a/portal.orchestra.com/app/roles/form-fields.ts
+++ b/portal.orchestra.com/app/roles/form-fields.ts
@@ -10,6 +10,14 @@ export const roleFormFields: FormField[] = [
     width: "full",
   },
   {
+    name: "code",
+    label: "Role Code",
+    type: "text",
+    required: true,
+    placeholder: "e.g., MANAGER",
+    width: "full",
+  },
+  {
     name: "description",
     label: "Description",
     type: "textarea",

--- a/portal.orchestra.com/app/roles/page.tsx
+++ b/portal.orchestra.com/app/roles/page.tsx
@@ -1,22 +1,31 @@
 'use client';
 
+import { useState, useMemo } from 'react';
 import { EntityManager } from "@/components/entity-manager";
-import { columns } from "./column";
+import { columns as baseColumns } from "./column";
 import { roleFormFields } from "./form-fields";
-import { Shield } from "lucide-react";
+import { Shield, Settings } from "lucide-react";
 import {
   useGetRolesQuery,
   useCreateRoleMutation,
   useUpdateRoleMutation,
   useDeleteRoleMutation,
+  Role,
 } from "@/store/api/rolesApi";
 import { toast } from "sonner";
+import { RoleDetailsPanel } from "@/components/roles/RoleDetailsPanel";
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import { Column } from "@/components/ui/data-table";
 
 export default function RolesPage() {
   const { data: roles = [], isLoading } = useGetRolesQuery();
   const [createRole] = useCreateRoleMutation();
   const [updateRole] = useUpdateRoleMutation();
   const [deleteRole] = useDeleteRoleMutation();
+  
+  const [selectedRole, setSelectedRole] = useState<Role | null>(null);
+  const [isPermissionDialogOpen, setIsPermissionDialogOpen] = useState(false);
 
   const stats = [
     {
@@ -24,6 +33,12 @@ export default function RolesPage() {
       value: roles.length,
       icon: Shield,
       color: "bg-purple-500/10 text-purple-600",
+    },
+    {
+      label: "Custom Roles",
+      value: roles.filter((r) => !r.isSystemRole).length,
+      icon: Shield,
+      color: "bg-blue-500/10 text-blue-600",
     },
   ];
 
@@ -39,6 +54,11 @@ export default function RolesPage() {
 
   const handleUpdate = async (id: string | number, formData: any) => {
     try {
+      const role = roles.find((r) => r.id === String(id));
+      if (role?.isSystemRole) {
+        toast.error("Cannot modify system roles");
+        throw new Error("Cannot modify system roles");
+      }
       await updateRole({ id: String(id), ...formData }).unwrap();
       toast.success("Role updated successfully");
     } catch (error) {
@@ -49,6 +69,11 @@ export default function RolesPage() {
 
   const handleDelete = async (id: string | number) => {
     try {
+      const role = roles.find((r) => r.id === String(id));
+      if (role?.isSystemRole) {
+        toast.error("Cannot delete system roles");
+        throw new Error("Cannot delete system roles");
+      }
       await deleteRole(String(id)).unwrap();
       toast.success("Role deleted successfully");
     } catch (error) {
@@ -57,20 +82,63 @@ export default function RolesPage() {
     }
   };
 
+  const handleManagePermissions = (role: Role) => {
+    setSelectedRole(role);
+    setIsPermissionDialogOpen(true);
+  };
+
+  // Add Manage Permissions column
+  const columns: Column<any>[] = useMemo(() => {
+    return [
+      ...baseColumns,
+      {
+        header: "Manage",
+        className: "text-center",
+        cell: (item: Role) => (
+          <Button
+            variant="outline"
+            size="sm"
+            className="gap-2"
+            onClick={() => handleManagePermissions(item)}
+          >
+            <Settings className="h-4 w-4" />
+            Permissions
+          </Button>
+        ),
+      },
+    ];
+  }, []);
+
   return (
-    <EntityManager
-      entityName="Role"
-      entityNamePlural="Roles"
-      data={roles}
-      columns={columns}
-      formFields={roleFormFields}
-      keyExtractor={(item) => item.id}
-      onCreate={handleCreate}
-      onUpdate={handleUpdate}
-      onDelete={handleDelete}
-      stats={stats}
-      searchPlaceholder="Search roles..."
-      isLoading={isLoading}
-    />
+    <>
+      <EntityManager
+        entityName="Role"
+        entityNamePlural="Roles"
+        data={roles}
+        columns={columns}
+        formFields={roleFormFields}
+        keyExtractor={(item) => item.id}
+        onCreate={handleCreate}
+        onUpdate={handleUpdate}
+        onDelete={handleDelete}
+        stats={stats}
+        searchPlaceholder="Search roles..."
+        isLoading={isLoading}
+      />
+
+      <Dialog open={isPermissionDialogOpen} onOpenChange={setIsPermissionDialogOpen}>
+        <DialogContent className="max-w-4xl max-h-[80vh] overflow-y-auto">
+          <DialogHeader>
+            <DialogTitle>Manage Role Permissions</DialogTitle>
+          </DialogHeader>
+          {selectedRole && (
+            <RoleDetailsPanel
+              role={selectedRole}
+              onClose={() => setIsPermissionDialogOpen(false)}
+            />
+          )}
+        </DialogContent>
+      </Dialog>
+    </>
   );
 }

--- a/portal.orchestra.com/app/users/page.tsx
+++ b/portal.orchestra.com/app/users/page.tsx
@@ -1,22 +1,31 @@
 'use client';
 
+import { useState, useMemo } from 'react';
 import { EntityManager } from "@/components/entity-manager";
-import { columns } from "./column";
+import { columns as baseColumns } from "./column";
 import { userFormFields } from "./form-fields";
-import { Users as UsersIcon } from "lucide-react";
+import { Users as UsersIcon, UserCog } from "lucide-react";
 import {
   useGetUsersQuery,
   useCreateUserMutation,
   useUpdateUserMutation,
   useDeleteUserMutation,
+  User,
 } from "@/store/api/usersApi";
 import { toast } from "sonner";
+import { UserRolesManager } from "@/components/users/UserRolesManager";
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import { Column } from "@/components/ui/data-table";
 
 export default function UsersPage() {
   const { data: users = [], isLoading } = useGetUsersQuery();
   const [createUser] = useCreateUserMutation();
   const [updateUser] = useUpdateUserMutation();
   const [deleteUser] = useDeleteUserMutation();
+
+  const [selectedUser, setSelectedUser] = useState<User | null>(null);
+  const [isRoleDialogOpen, setIsRoleDialogOpen] = useState(false);
 
   const stats = [
     {
@@ -55,7 +64,7 @@ export default function UsersPage() {
 
   const handleDelete = async (id: string | number) => {
     try {
-      await deleteUser(String(id)).unwrap();
+      await deleteUser(Number(id)).unwrap();
       toast.success("User deleted successfully");
     } catch (error) {
       toast.error("Failed to delete user");
@@ -63,20 +72,63 @@ export default function UsersPage() {
     }
   };
 
+  const handleManageRoles = (user: User) => {
+    setSelectedUser(user);
+    setIsRoleDialogOpen(true);
+  };
+
+  // Add Manage Roles column
+  const columns: Column<any>[] = useMemo(() => {
+    return [
+      ...baseColumns,
+      {
+        header: "Manage",
+        className: "text-center",
+        cell: (item: User) => (
+          <Button
+            variant="outline"
+            size="sm"
+            className="gap-2"
+            onClick={() => handleManageRoles(item)}
+          >
+            <UserCog className="h-4 w-4" />
+            Roles
+          </Button>
+        ),
+      },
+    ];
+  }, []);
+
   return (
-    <EntityManager
-      entityName="User"
-      entityNamePlural="Users"
-      data={users}
-      columns={columns}
-      formFields={userFormFields}
-      keyExtractor={(item) => item.id}
-      onCreate={handleCreate}
-      onUpdate={handleUpdate}
-      onDelete={handleDelete}
-      stats={stats}
-      searchPlaceholder="Search users..."
-      isLoading={isLoading}
-    />
+    <>
+      <EntityManager
+        entityName="User"
+        entityNamePlural="Users"
+        data={users}
+        columns={columns}
+        formFields={userFormFields}
+        keyExtractor={(item) => item.id}
+        onCreate={handleCreate}
+        onUpdate={handleUpdate}
+        onDelete={handleDelete}
+        stats={stats}
+        searchPlaceholder="Search users..."
+        isLoading={isLoading}
+      />
+
+      <Dialog open={isRoleDialogOpen} onOpenChange={setIsRoleDialogOpen}>
+        <DialogContent className="max-w-2xl">
+          <DialogHeader>
+            <DialogTitle>Manage User Roles</DialogTitle>
+          </DialogHeader>
+          {selectedUser && (
+            <UserRolesManager
+              user={selectedUser}
+              onClose={() => setIsRoleDialogOpen(false)}
+            />
+          )}
+        </DialogContent>
+      </Dialog>
+    </>
   );
 }

--- a/portal.orchestra.com/components/roles/PermissionPicker.tsx
+++ b/portal.orchestra.com/components/roles/PermissionPicker.tsx
@@ -1,0 +1,117 @@
+'use client';
+
+import { useState } from 'react';
+import { Permission } from '@/store/api/rolesApi';
+import { Checkbox } from '@/components/ui/checkbox';
+import { Label } from '@/components/ui/label';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+
+interface PermissionPickerProps {
+  permissions: Permission[];
+  selectedPermissionIds: number[];
+  onChange: (permissionIds: number[]) => void;
+}
+
+export function PermissionPicker({
+  permissions,
+  selectedPermissionIds,
+  onChange,
+}: PermissionPickerProps) {
+  // Group permissions by module
+  const groupedPermissions = permissions.reduce((acc, permission) => {
+    if (!acc[permission.module]) {
+      acc[permission.module] = [];
+    }
+    acc[permission.module].push(permission);
+    return acc;
+  }, {} as Record<string, Permission[]>);
+
+  const handleToggle = (permissionId: number) => {
+    const newSelected = selectedPermissionIds.includes(permissionId)
+      ? selectedPermissionIds.filter((id) => id !== permissionId)
+      : [...selectedPermissionIds, permissionId];
+    onChange(newSelected);
+  };
+
+  const handleSelectAllModule = (module: string) => {
+    const modulePermissions = groupedPermissions[module];
+    const modulePermissionIds = modulePermissions.map((p) => p.id);
+    const allSelected = modulePermissionIds.every((id) =>
+      selectedPermissionIds.includes(id)
+    );
+
+    if (allSelected) {
+      // Deselect all from this module
+      onChange(
+        selectedPermissionIds.filter((id) => !modulePermissionIds.includes(id))
+      );
+    } else {
+      // Select all from this module
+      const newSelected = [
+        ...selectedPermissionIds,
+        ...modulePermissionIds.filter((id) => !selectedPermissionIds.includes(id)),
+      ];
+      onChange(newSelected);
+    }
+  };
+
+  return (
+    <div className="space-y-4">
+      {Object.entries(groupedPermissions).map(([module, modulePermissions]) => {
+        const modulePermissionIds = modulePermissions.map((p) => p.id);
+        const allSelected = modulePermissionIds.every((id) =>
+          selectedPermissionIds.includes(id)
+        );
+        const someSelected = modulePermissionIds.some((id) =>
+          selectedPermissionIds.includes(id)
+        );
+
+        return (
+          <Card key={module}>
+            <CardHeader className="pb-3">
+              <div className="flex items-center justify-between">
+                <CardTitle className="text-base font-medium uppercase">
+                  {module}
+                </CardTitle>
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={() => handleSelectAllModule(module)}
+                >
+                  {allSelected ? 'Deselect All' : 'Select All'}
+                </Button>
+              </div>
+            </CardHeader>
+            <CardContent>
+              <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
+                {modulePermissions.map((permission) => (
+                  <div key={permission.id} className="flex items-start space-x-2">
+                    <Checkbox
+                      id={`permission-${permission.id}`}
+                      checked={selectedPermissionIds.includes(permission.id)}
+                      onCheckedChange={() => handleToggle(permission.id)}
+                    />
+                    <div className="grid gap-1.5 leading-none">
+                      <Label
+                        htmlFor={`permission-${permission.id}`}
+                        className="text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70 cursor-pointer"
+                      >
+                        {permission.resource}.{permission.action}
+                      </Label>
+                      {permission.description && (
+                        <p className="text-xs text-muted-foreground">
+                          {permission.description}
+                        </p>
+                      )}
+                    </div>
+                  </div>
+                ))}
+              </div>
+            </CardContent>
+          </Card>
+        );
+      })}
+    </div>
+  );
+}

--- a/portal.orchestra.com/components/roles/RoleDetailsPanel.tsx
+++ b/portal.orchestra.com/components/roles/RoleDetailsPanel.tsx
@@ -1,0 +1,107 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+import { Role, Permission, useGetPermissionsQuery, useAssignPermissionsMutation } from '@/store/api/rolesApi';
+import { PermissionPicker } from './PermissionPicker';
+import { Button } from '@/components/ui/button';
+import { toast } from 'sonner';
+import { Loader2 } from 'lucide-react';
+
+interface RoleDetailsPanelProps {
+  role: Role;
+  onClose?: () => void;
+}
+
+export function RoleDetailsPanel({ role, onClose }: RoleDetailsPanelProps) {
+  const { data: permissions = [], isLoading: isLoadingPermissions } = useGetPermissionsQuery();
+  const [assignPermissions, { isLoading: isAssigning }] = useAssignPermissionsMutation();
+  
+  const [selectedPermissionIds, setSelectedPermissionIds] = useState<number[]>([]);
+
+  // Initialize selected permissions from role
+  useEffect(() => {
+    if (role.rolePermissions) {
+      const ids = role.rolePermissions.map((rp) => rp.permission.id);
+      setSelectedPermissionIds(ids);
+    }
+  }, [role]);
+
+  const handleSave = async () => {
+    try {
+      await assignPermissions({
+        roleId: role.id,
+        permissionIds: selectedPermissionIds,
+      }).unwrap();
+      toast.success('Permissions updated successfully');
+      onClose?.();
+    } catch (error) {
+      toast.error('Failed to update permissions');
+    }
+  };
+
+  const hasChanges = () => {
+    const currentIds = role.rolePermissions?.map((rp) => rp.permission.id) || [];
+    if (currentIds.length !== selectedPermissionIds.length) return true;
+    return !currentIds.every((id) => selectedPermissionIds.includes(id));
+  };
+
+  if (isLoadingPermissions) {
+    return (
+      <div className="flex items-center justify-center p-8">
+        <Loader2 className="h-8 w-8 animate-spin" />
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h3 className="text-lg font-semibold">{role.name}</h3>
+        <p className="text-sm text-muted-foreground">{role.description}</p>
+        {role.isSystemRole && (
+          <p className="text-xs text-amber-600 mt-1">
+            System role - permissions are managed by the system
+          </p>
+        )}
+      </div>
+
+      {!role.isSystemRole && (
+        <>
+          <PermissionPicker
+            permissions={permissions}
+            selectedPermissionIds={selectedPermissionIds}
+            onChange={setSelectedPermissionIds}
+          />
+
+          <div className="flex justify-end gap-2">
+            {onClose && (
+              <Button variant="outline" onClick={onClose}>
+                Cancel
+              </Button>
+            )}
+            <Button
+              onClick={handleSave}
+              disabled={!hasChanges() || isAssigning}
+            >
+              {isAssigning && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+              Save Permissions
+            </Button>
+          </div>
+        </>
+      )}
+
+      {role.isSystemRole && (
+        <div className="bg-muted p-4 rounded-lg">
+          <h4 className="font-medium mb-2">Current Permissions</h4>
+          <div className="space-y-1">
+            {role.rolePermissions?.map((rp) => (
+              <div key={rp.permission.id} className="text-sm">
+                {rp.permission.module}.{rp.permission.resource}.{rp.permission.action}
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/portal.orchestra.com/components/ui/checkbox.tsx
+++ b/portal.orchestra.com/components/ui/checkbox.tsx
@@ -1,0 +1,30 @@
+"use client"
+
+import * as React from "react"
+import * as CheckboxPrimitive from "@radix-ui/react-checkbox"
+import { Check } from "lucide-react"
+
+import { cn } from "@/lib/utils"
+
+const Checkbox = React.forwardRef<
+  React.ElementRef<typeof CheckboxPrimitive.Root>,
+  React.ComponentPropsWithoutRef<typeof CheckboxPrimitive.Root>
+>(({ className, ...props }, ref) => (
+  <CheckboxPrimitive.Root
+    ref={ref}
+    className={cn(
+      "peer h-4 w-4 shrink-0 rounded-sm border border-primary ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:bg-primary data-[state=checked]:text-primary-foreground",
+      className
+    )}
+    {...props}
+  >
+    <CheckboxPrimitive.Indicator
+      className={cn("flex items-center justify-center text-current")}
+    >
+      <Check className="h-4 w-4" />
+    </CheckboxPrimitive.Indicator>
+  </CheckboxPrimitive.Root>
+))
+Checkbox.displayName = CheckboxPrimitive.Root.displayName
+
+export { Checkbox }

--- a/portal.orchestra.com/components/users/UserRolesManager.tsx
+++ b/portal.orchestra.com/components/users/UserRolesManager.tsx
@@ -1,0 +1,144 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+import { User } from '@/store/api/usersApi';
+import { useGetRolesQuery, useAssignUsersMutation, useRemoveUserFromRoleMutation } from '@/store/api/rolesApi';
+import { Checkbox } from '@/components/ui/checkbox';
+import { Label } from '@/components/ui/label';
+import { Button } from '@/components/ui/button';
+import { toast } from 'sonner';
+import { Loader2 } from 'lucide-react';
+
+interface UserRolesManagerProps {
+  user: User;
+  onClose?: () => void;
+}
+
+export function UserRolesManager({ user, onClose }: UserRolesManagerProps) {
+  const { data: roles = [], isLoading: isLoadingRoles } = useGetRolesQuery();
+  const [assignUsers] = useAssignUsersMutation();
+  const [removeUserFromRole] = useRemoveUserFromRoleMutation();
+  
+  const [selectedRoleIds, setSelectedRoleIds] = useState<string[]>([]);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  // Initialize selected roles from user
+  useEffect(() => {
+    if (user.userRoles) {
+      const roleIds = user.userRoles
+        .map((ur) => ur.role?.id)
+        .filter((id): id is number => id !== undefined);
+      setSelectedRoleIds(roleIds.map(String));
+    }
+  }, [user]);
+
+  const handleToggle = (roleId: string) => {
+    setSelectedRoleIds((prev) =>
+      prev.includes(roleId)
+        ? prev.filter((id) => id !== roleId)
+        : [...prev, roleId]
+    );
+  };
+
+  const handleSave = async () => {
+    setIsSubmitting(true);
+    try {
+      const currentRoleIds = user.userRoles?.map((ur) => String(ur.role?.id)) || [];
+      
+      // Roles to add
+      const rolesToAdd = selectedRoleIds.filter((id) => !currentRoleIds.includes(id));
+      
+      // Roles to remove
+      const rolesToRemove = currentRoleIds.filter((id) => !selectedRoleIds.includes(id));
+
+      // Assign new roles
+      for (const roleId of rolesToAdd) {
+        await assignUsers({
+          roleId,
+          userIds: [user.id],
+        }).unwrap();
+      }
+
+      // Remove old roles
+      for (const roleId of rolesToRemove) {
+        await removeUserFromRole({
+          roleId,
+          userId: user.id,
+        }).unwrap();
+      }
+
+      toast.success('User roles updated successfully');
+      onClose?.();
+    } catch (error) {
+      toast.error('Failed to update user roles');
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  const hasChanges = () => {
+    const currentIds = user.userRoles?.map((ur) => String(ur.role?.id)) || [];
+    if (currentIds.length !== selectedRoleIds.length) return true;
+    return !currentIds.every((id) => selectedRoleIds.includes(id));
+  };
+
+  if (isLoadingRoles) {
+    return (
+      <div className="flex items-center justify-center p-8">
+        <Loader2 className="h-8 w-8 animate-spin" />
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h3 className="text-lg font-semibold">
+          {user.firstName} {user.lastName}
+        </h3>
+        <p className="text-sm text-muted-foreground">{user.email}</p>
+      </div>
+
+      <div className="space-y-3">
+        <h4 className="font-medium">Assign Roles</h4>
+        {roles.map((role) => (
+          <div key={role.id} className="flex items-start space-x-2">
+            <Checkbox
+              id={`role-${role.id}`}
+              checked={selectedRoleIds.includes(role.id)}
+              onCheckedChange={() => handleToggle(role.id)}
+            />
+            <div className="grid gap-1.5 leading-none">
+              <Label
+                htmlFor={`role-${role.id}`}
+                className="text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70 cursor-pointer"
+              >
+                {role.name}
+              </Label>
+              {role.description && (
+                <p className="text-xs text-muted-foreground">
+                  {role.description}
+                </p>
+              )}
+            </div>
+          </div>
+        ))}
+      </div>
+
+      <div className="flex justify-end gap-2">
+        {onClose && (
+          <Button variant="outline" onClick={onClose}>
+            Cancel
+          </Button>
+        )}
+        <Button
+          onClick={handleSave}
+          disabled={!hasChanges() || isSubmitting}
+        >
+          {isSubmitting && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+          Save Roles
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/portal.orchestra.com/package.json
+++ b/portal.orchestra.com/package.json
@@ -10,6 +10,7 @@
   },
   "dependencies": {
     "@radix-ui/react-avatar": "^1.1.11",
+    "@radix-ui/react-checkbox": "^1.3.3",
     "@radix-ui/react-collapsible": "^1.1.12",
     "@radix-ui/react-dialog": "^1.1.15",
     "@radix-ui/react-label": "^2.1.8",

--- a/portal.orchestra.com/pnpm-lock.yaml
+++ b/portal.orchestra.com/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
       '@radix-ui/react-avatar':
         specifier: ^1.1.11
         version: 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@radix-ui/react-checkbox':
+        specifier: ^1.3.3
+        version: 1.3.3(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       '@radix-ui/react-collapsible':
         specifier: ^1.1.12
         version: 1.1.12(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
@@ -495,6 +498,19 @@ packages:
 
   '@radix-ui/react-avatar@1.1.11':
     resolution: {integrity: sha512-0Qk603AHGV28BOBO34p7IgD5m+V5Sg/YovfayABkoDDBM5d3NCx0Mp4gGrjzLGes1jV5eNOE1r3itqOR33VC6Q==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-checkbox@1.3.3':
+    resolution: {integrity: sha512-wBbpv+NQftHDdG86Qc0pIyXk5IR3tM8Vd0nWLKDcX8nNn4nXFOFwsKuqw2okA/1D/mpaAkmuyndrPJTYDNZtFw==}
     peerDependencies:
       '@types/react': '*'
       '@types/react-dom': '*'
@@ -2905,6 +2921,22 @@ snapshots:
       '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.2.8)(react@19.2.3)
       '@radix-ui/react-use-is-hydrated': 0.1.0(@types/react@19.2.8)(react@19.2.3)
       '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.8)(react@19.2.3)
+      react: 19.2.3
+      react-dom: 19.2.3(react@19.2.3)
+    optionalDependencies:
+      '@types/react': 19.2.8
+      '@types/react-dom': 19.2.3(@types/react@19.2.8)
+
+  '@radix-ui/react-checkbox@1.3.3(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.8)(react@19.2.3)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.8)(react@19.2.3)
+      '@radix-ui/react-presence': 1.1.5(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.8)(react@19.2.3)
+      '@radix-ui/react-use-previous': 1.1.1(@types/react@19.2.8)(react@19.2.3)
+      '@radix-ui/react-use-size': 1.1.1(@types/react@19.2.8)(react@19.2.3)
       react: 19.2.3
       react-dom: 19.2.3(react@19.2.3)
     optionalDependencies:

--- a/portal.orchestra.com/store/api/rolesApi.ts
+++ b/portal.orchestra.com/store/api/rolesApi.ts
@@ -3,7 +3,22 @@ import { createApi, fetchBaseQuery } from '@reduxjs/toolkit/query/react';
 export interface Role {
   id: string;
   name: string;
+  code: string;
   description: string;
+  isSystemRole?: boolean;
+  rolePermissions?: Array<{
+    permission: Permission;
+  }>;
+}
+
+export interface Permission {
+  id: number;
+  module: string;
+  resource: string;
+  action: string;
+  slug: string;
+  description?: string;
+  isActive: boolean;
 }
 
 export const rolesApi = createApi({
@@ -16,10 +31,10 @@ export const rolesApi = createApi({
     },
     credentials: 'include',
   }),
-  tagTypes: ['Role'],
+  tagTypes: ['Role', 'Permission', 'User'],
   endpoints: (builder) => ({
     getRoles: builder.query<Role[], void>({
-      query: () => '/roles',
+      query: () => '/system/roles',
       providesTags: (result) =>
         result
           ? [
@@ -29,12 +44,12 @@ export const rolesApi = createApi({
           : [{ type: 'Role', id: 'LIST' }],
     }),
     getRole: builder.query<Role, string>({
-      query: (id) => `/roles/${id}`,
+      query: (id) => `/system/roles/${id}`,
       providesTags: (_result, _error, id) => [{ type: 'Role', id }],
     }),
-    createRole: builder.mutation<Role, Omit<Role, 'id'>>({
+    createRole: builder.mutation<Role, Omit<Role, 'id'> & { permissionIds?: number[] }>({
       query: (data) => ({
-        url: '/roles',
+        url: '/system/roles',
         method: 'POST',
         body: data,
       }),
@@ -42,7 +57,7 @@ export const rolesApi = createApi({
     }),
     updateRole: builder.mutation<Role, Partial<Role> & Pick<Role, 'id'>>({
       query: ({ id, ...patch }) => ({
-        url: `/roles/${id}`,
+        url: `/system/roles/${id}`,
         method: 'PATCH',
         body: patch,
       }),
@@ -50,10 +65,51 @@ export const rolesApi = createApi({
     }),
     deleteRole: builder.mutation<void, string>({
       query: (id) => ({
-        url: `/roles/${id}`,
+        url: `/system/roles/${id}`,
         method: 'DELETE',
       }),
       invalidatesTags: [{ type: 'Role', id: 'LIST' }],
+    }),
+    getPermissions: builder.query<Permission[], void>({
+      query: () => '/system/permissions',
+      providesTags: [{ type: 'Permission', id: 'LIST' }],
+    }),
+    assignPermissions: builder.mutation<Role, { roleId: string; permissionIds: number[] }>({
+      query: ({ roleId, permissionIds }) => ({
+        url: `/system/roles/${roleId}/permissions`,
+        method: 'POST',
+        body: { permissionIds },
+      }),
+      invalidatesTags: (_result, _error, { roleId }) => [{ type: 'Role', id: roleId }],
+    }),
+    removePermissions: builder.mutation<Role, { roleId: string; permissionIds: number[] }>({
+      query: ({ roleId, permissionIds }) => ({
+        url: `/system/roles/${roleId}/permissions`,
+        method: 'DELETE',
+        body: { permissionIds },
+      }),
+      invalidatesTags: (_result, _error, { roleId }) => [{ type: 'Role', id: roleId }],
+    }),
+    assignUsers: builder.mutation<Role, { roleId: string; userIds: number[] }>({
+      query: ({ roleId, userIds }) => ({
+        url: `/system/roles/${roleId}/users`,
+        method: 'POST',
+        body: { userIds },
+      }),
+      invalidatesTags: (_result, _error, { roleId }) => [
+        { type: 'Role', id: roleId },
+        { type: 'User', id: 'LIST' },
+      ],
+    }),
+    removeUserFromRole: builder.mutation<void, { roleId: string; userId: number }>({
+      query: ({ roleId, userId }) => ({
+        url: `/system/roles/${roleId}/users/${userId}`,
+        method: 'DELETE',
+      }),
+      invalidatesTags: (_result, _error, { roleId }) => [
+        { type: 'Role', id: roleId },
+        { type: 'User', id: 'LIST' },
+      ],
     }),
   }),
 });
@@ -64,4 +120,9 @@ export const {
   useCreateRoleMutation,
   useUpdateRoleMutation,
   useDeleteRoleMutation,
+  useGetPermissionsQuery,
+  useAssignPermissionsMutation,
+  useRemovePermissionsMutation,
+  useAssignUsersMutation,
+  useRemoveUserFromRoleMutation,
 } = rolesApi;


### PR DESCRIPTION
## 🔍 Overview

This PR completes the management interface for the Role-Based Access Control (RBAC) system. It enables Tenant Admins to dynamically manage custom roles, assign granular permission slugs, and link users to roles through a new modal-based management flow in the portal.

## 🚀 Key Changes

* **[Backend (Roles Module)]**: Implemented `assignUsers` and `removeUser` endpoints in `RoleController` and `RoleService` with `AssignUsersDto` validation.
* **[Frontend (RBAC Components)]**: Developed `PermissionPicker.tsx` for hierarchical selection, `UserRolesManager.tsx` for role assignments, and `RoleDetailsPanel.tsx` for role editing.
* **[Frontend (Pages)]**: Integrated `Roles` and `Users` entity pages with new management components using shadcn/ui Dialogs.
* **[API Overlay]**: Expanded `rolesApi.ts` with RTK Query mutations and multi-tag cache invalidation (`Role`, `User`, `Permission`).

## 🔗 Related Issues/Epics

* Fixes # (No specific issue linked)
* Relates to EPIC-01 (RBAC Foundation) and EPIC-02 (Frontend Implementation)

## 🧪 Testing Performed

* [x] Manual verification of role creation and editing in the browser.
* [x] Verified user-to-role assignment persistence in the PostgreSQL database.
* [x] Checked that multi-tenant scoping prevents access to other company roles.
* [x] Verified that system-level roles (e.g., ADMIN) remain protected from UI deletions.


## 🚩 Checklist

* [x] My code follows the style guidelines of this project
* [x] I have performed a self-review of my own code
* [x] I have commented my code, particularly in hard-to-understand areas
* [x] I have made corresponding changes to the documentation
* [x] My changes generate no new warnings

