### PR TITLE
feat(rbac): migrate controllers to slug-based permission enforcement

### DIFF
--- a/api.orchestra.com/src/entities/system/permission.entity.ts
+++ b/api.orchestra.com/src/entities/system/permission.entity.ts
@@ -1,5 +1,8 @@
 import { Column, Entity, Index, OneToMany } from 'typeorm';
 import { CommonEntity } from '../common.entity';
+import { RolePermission } from './role-permission.entity';
+import { UserPermission } from './user-permission.entity';
+import { Menu } from './menu.entity';
 
 @Entity({ name: 'permissions', schema: 'system' })
 @Index(['slug'], { unique: true, where: 'deleted_at IS NULL' })
@@ -30,11 +33,11 @@ export class Permission extends CommonEntity {
 
   // Relationships
   @OneToMany('RolePermission', 'permission')
-  rolePermissions!: import('./role-permission.entity').RolePermission[];
+  rolePermissions!: RolePermission[];
 
   @OneToMany('UserPermission', 'permission')
-  userPermissions!: import('./user-permission.entity').UserPermission[];
+  userPermissions!: UserPermission[];
 
   @OneToMany('Menu', 'permission')
-  menus!: import('./menu.entity').Menu[];
+  menus!: Menu[];
 }

--- a/api.orchestra.com/src/entities/system/role-permission.entity.ts
+++ b/api.orchestra.com/src/entities/system/role-permission.entity.ts
@@ -1,5 +1,7 @@
 import { Column, Entity, Index, ManyToOne, JoinColumn } from 'typeorm';
 import { CommonEntity } from '../common.entity';
+import { Role } from './role.entity';
+import { Permission } from './permission.entity';
 
 @Entity({ name: 'role_permissions', schema: 'system' })
 @Index(['roleId', 'permissionId'], {
@@ -13,7 +15,7 @@ export class RolePermission extends CommonEntity {
 
   @ManyToOne('Role', 'rolePermissions', { onDelete: 'CASCADE' })
   @JoinColumn({ name: 'role_id' })
-  role!: import('./role.entity').Role;
+  role!: Role;
 
   @Column({ name: 'permission_id', type: 'int' })
   @Index()
@@ -21,5 +23,5 @@ export class RolePermission extends CommonEntity {
 
   @ManyToOne('Permission', 'rolePermissions', { onDelete: 'CASCADE' })
   @JoinColumn({ name: 'permission_id' })
-  permission!: import('./permission.entity').Permission;
+  permission!: Permission;
 }

--- a/api.orchestra.com/src/entities/system/role.entity.ts
+++ b/api.orchestra.com/src/entities/system/role.entity.ts
@@ -9,6 +9,8 @@ import {
 import { CommonEntity } from '../common.entity';
 import { Tenant } from './tenant.entity';
 import { RoleStatus } from '@/types/enums';
+import { UserRole } from './user-role.entity';
+import { RolePermission } from './role-permission.entity';
 
 @Entity({ name: 'roles', schema: 'system' })
 @Index(['code'], { unique: true, where: 'deleted_at IS NULL' })
@@ -42,8 +44,8 @@ export class Role extends CommonEntity {
 
   // Relationships
   @OneToMany('UserRole', 'role')
-  userRoles!: import('./user-role.entity').UserRole[];
+  userRoles!: UserRole[];
 
   @OneToMany('RolePermission', 'role')
-  rolePermissions!: import('./role-permission.entity').RolePermission[];
+  rolePermissions!: RolePermission[];
 }

--- a/api.orchestra.com/src/entities/system/user-permission.entity.ts
+++ b/api.orchestra.com/src/entities/system/user-permission.entity.ts
@@ -1,5 +1,7 @@
 import { Column, Entity, Index, ManyToOne, JoinColumn } from 'typeorm';
 import { CommonEntity } from '../common.entity';
+import { User } from './user.entity';
+import { Permission } from './permission.entity';
 
 /**
  * UserPermission entity for direct user-level permission overrides.
@@ -19,7 +21,7 @@ export class UserPermission extends CommonEntity {
 
   @ManyToOne('User', 'userPermissions', { onDelete: 'CASCADE' })
   @JoinColumn({ name: 'user_id' })
-  user!: import('./user.entity').User;
+  user!: User;
 
   @Column({ name: 'permission_id', type: 'int' })
   @Index()
@@ -27,7 +29,7 @@ export class UserPermission extends CommonEntity {
 
   @ManyToOne('Permission', 'userPermissions', { onDelete: 'CASCADE' })
   @JoinColumn({ name: 'permission_id' })
-  permission!: import('./permission.entity').Permission;
+  permission!: Permission;
 
   @Column({
     type: 'varchar',

--- a/api.orchestra.com/src/entities/system/user-role.entity.ts
+++ b/api.orchestra.com/src/entities/system/user-role.entity.ts
@@ -1,5 +1,7 @@
 import { Column, Entity, Index, ManyToOne, JoinColumn } from 'typeorm';
 import { CommonEntity } from '../common.entity';
+import { User } from './user.entity';
+import { Role } from './role.entity';
 
 @Entity({ name: 'user_roles', schema: 'system' })
 @Index(['userId', 'roleId'], { unique: true, where: 'deleted_at IS NULL' })
@@ -10,7 +12,7 @@ export class UserRole extends CommonEntity {
 
   @ManyToOne('User', 'userRoles', { onDelete: 'CASCADE' })
   @JoinColumn({ name: 'user_id' })
-  user!: import('./user.entity').User;
+  user!: User;
 
   @Column({ name: 'role_id', type: 'int' })
   @Index()
@@ -18,7 +20,7 @@ export class UserRole extends CommonEntity {
 
   @ManyToOne('Role', 'userRoles', { onDelete: 'CASCADE' })
   @JoinColumn({ name: 'role_id' })
-  role!: import('./role.entity').Role;
+  role!: Role;
 
   @Column({
     name: 'assigned_at',

--- a/api.orchestra.com/src/entities/system/user.entity.ts
+++ b/api.orchestra.com/src/entities/system/user.entity.ts
@@ -9,6 +9,8 @@ import {
 import { CommonEntity } from '../common.entity';
 import { Status } from '@/types/enums';
 import { Tenant } from './tenant.entity';
+import { UserRole } from './user-role.entity';
+import { UserPermission } from './user-permission.entity';
 
 @Entity({ name: 'users', schema: 'system' })
 @Index(['email'], { unique: true, where: 'deleted_at IS NULL' })
@@ -56,8 +58,8 @@ export class User extends CommonEntity {
 
   // Relationships
   @OneToMany('UserRole', 'user')
-  userRoles!: import('./user-role.entity').UserRole[];
+  userRoles!: UserRole[];
 
   @OneToMany('UserPermission', 'user')
-  userPermissions!: import('./user-permission.entity').UserPermission[];
+  userPermissions!: UserPermission[];
 }

--- a/api.orchestra.com/src/modules/system/permissions/permission.controller.ts
+++ b/api.orchestra.com/src/modules/system/permissions/permission.controller.ts
@@ -15,20 +15,19 @@ import {
 } from '@nestjs/swagger';
 import { PermissionService } from './permission.service';
 import { CheckPermissionDto } from './dto/check-permission.dto';
-import { Roles } from '@/decorators/roles.decorator';
+import { RequirePermissions } from '@/decorators/require-permissions.decorator';
 import { AuthenticatedGuard } from '@/guards/authenticated.guard';
-import { RolesGuard } from '@/guards/roles.guard';
+import { PermissionsGuard } from '@/guards/permissions.guard';
 
 /**
  * Controller for managing Permission resources.
  *
  * Provides endpoints for listing permissions and checking user access.
- * Access is restricted to users with ADMIN role.
+ * Access is controlled via slug-based permissions (system.permission.view).
  */
 @ApiTags('Permissions')
 @ApiBearerAuth()
-@UseGuards(AuthenticatedGuard, RolesGuard)
-@Roles('ADMIN')
+@UseGuards(AuthenticatedGuard, PermissionsGuard)
 @Controller('system/permissions')
 export class PermissionController {
   constructor(private readonly permissionService: PermissionService) {}
@@ -39,6 +38,7 @@ export class PermissionController {
    * @returns List of all permissions
    */
   @Get()
+  @RequirePermissions('system.permission.view')
   @ApiOperation({ summary: 'List all permissions' })
   @ApiResponse({
     status: 200,
@@ -46,7 +46,7 @@ export class PermissionController {
   })
   @ApiResponse({
     status: 403,
-    description: 'Forbidden - Admin access required.',
+    description: 'Forbidden - Insufficient permissions.',
   })
   findAll() {
     return this.permissionService.findAll();

--- a/api.orchestra.com/src/modules/system/roles/role.controller.ts
+++ b/api.orchestra.com/src/modules/system/roles/role.controller.ts
@@ -25,8 +25,8 @@ import { UpdateRoleDto } from './dto/update-role.dto';
 import { AssignPermissionsDto } from './dto/assign-permissions.dto';
 import { AssignUsersDto } from './dto/assign-users.dto';
 import { AuthenticatedGuard } from '@/guards/authenticated.guard';
-import { RolesGuard } from '@/guards/roles.guard';
-import { Roles } from '@/decorators/roles.decorator';
+import { PermissionsGuard } from '@/guards/permissions.guard';
+import { RequirePermissions } from '@/decorators/require-permissions.decorator';
 import { Role } from '@/entities/system/role.entity';
 import { User } from '@/entities/system/user.entity';
 
@@ -38,12 +38,11 @@ interface AuthenticatedRequest extends Request {
  * Controller for managing Role resources.
  *
  * Provides CRUD endpoints and permission assignment.
- * Access is restricted to users with ADMIN role.
+ * Access is controlled via slug-based permissions (system.role.view / system.role.manage).
  */
 @ApiTags('Roles')
 @ApiBearerAuth()
-@UseGuards(AuthenticatedGuard, RolesGuard)
-@Roles('ADMIN')
+@UseGuards(AuthenticatedGuard, PermissionsGuard)
 @Controller('system/roles')
 export class RoleController {
   constructor(private readonly roleService: RoleService) {}
@@ -52,6 +51,7 @@ export class RoleController {
    * Lists all roles.
    */
   @Get()
+  @RequirePermissions('system.role.view')
   @ApiOperation({ summary: 'List all roles' })
   @ApiResponse({ status: 200, description: 'Returns all roles.' })
   findAll(@Req() req: AuthenticatedRequest): Promise<Role[]> {
@@ -62,6 +62,7 @@ export class RoleController {
    * Gets a role by ID with its permissions.
    */
   @Get(':id')
+  @RequirePermissions('system.role.view')
   @ApiOperation({ summary: 'Get role by ID with permissions' })
   @ApiParam({ name: 'id', type: Number })
   @ApiResponse({
@@ -80,6 +81,7 @@ export class RoleController {
    * Creates a new role.
    */
   @Post()
+  @RequirePermissions('system.role.manage')
   @ApiOperation({ summary: 'Create a new role' })
   @ApiBody({ type: CreateRoleDto })
   @ApiResponse({ status: 201, description: 'Role created successfully.' })
@@ -95,6 +97,7 @@ export class RoleController {
    * Updates an existing role.
    */
   @Patch(':id')
+  @RequirePermissions('system.role.manage')
   @ApiOperation({ summary: 'Update a role' })
   @ApiParam({ name: 'id', type: Number })
   @ApiBody({ type: UpdateRoleDto })
@@ -112,6 +115,7 @@ export class RoleController {
    * Soft deletes a role.
    */
   @Delete(':id')
+  @RequirePermissions('system.role.manage')
   @ApiOperation({ summary: 'Delete a role' })
   @ApiParam({ name: 'id', type: Number })
   @ApiResponse({ status: 200, description: 'Role deleted successfully.' })
@@ -127,6 +131,7 @@ export class RoleController {
    * Assigns permissions to a role.
    */
   @Post(':id/permissions')
+  @RequirePermissions('system.role.manage')
   @ApiOperation({ summary: 'Assign permissions to a role' })
   @ApiParam({ name: 'id', type: Number })
   @ApiBody({ type: AssignPermissionsDto })
@@ -151,6 +156,7 @@ export class RoleController {
    * Removes permissions from a role.
    */
   @Delete(':id/permissions')
+  @RequirePermissions('system.role.manage')
   @ApiOperation({ summary: 'Remove permissions from a role' })
   @ApiParam({ name: 'id', type: Number })
   @ApiBody({ type: AssignPermissionsDto })
@@ -175,6 +181,7 @@ export class RoleController {
    * Assigns users to a role.
    */
   @Post(':id/users')
+  @RequirePermissions('system.role.manage')
   @ApiOperation({ summary: 'Assign users to a role' })
   @ApiParam({ name: 'id', type: Number })
   @ApiBody({ type: AssignUsersDto })
@@ -199,6 +206,7 @@ export class RoleController {
    * Removes a user from a role.
    */
   @Delete(':id/users/:userId')
+  @RequirePermissions('system.role.manage')
   @ApiOperation({ summary: 'Remove a user from a role' })
   @ApiParam({ name: 'id', type: Number })
   @ApiParam({ name: 'userId', type: Number })

--- a/api.orchestra.com/src/modules/system/roles/role.module.ts
+++ b/api.orchestra.com/src/modules/system/roles/role.module.ts
@@ -5,9 +5,14 @@ import { RoleService } from './role.service';
 import { Role } from '@/entities/system/role.entity';
 import { RolePermission } from '@/entities/system/role-permission.entity';
 import { Permission } from '@/entities/system/permission.entity';
+import { UserRole } from '@/entities/system/user-role.entity';
+import { PermissionModule } from '@/modules/system/permissions/permission.module';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([Role, RolePermission, Permission])],
+  imports: [
+    TypeOrmModule.forFeature([Role, RolePermission, Permission, UserRole]),
+    PermissionModule,
+  ],
   controllers: [RoleController],
   providers: [RoleService],
   exports: [RoleService],

--- a/api.orchestra.com/src/modules/system/roles/role.service.ts
+++ b/api.orchestra.com/src/modules/system/roles/role.service.ts
@@ -4,6 +4,7 @@ import { Repository, In } from 'typeorm';
 import { Role } from '@/entities/system/role.entity';
 import { RolePermission } from '@/entities/system/role-permission.entity';
 import { Permission } from '@/entities/system/permission.entity';
+import { UserRole } from '@/entities/system/user-role.entity';
 import { CreateRoleDto } from './dto/create-role.dto';
 import { UpdateRoleDto } from './dto/update-role.dto';
 
@@ -19,6 +20,8 @@ export class RoleService {
     private readonly rolePermissionRepository: Repository<RolePermission>,
     @InjectRepository(Permission)
     private readonly permissionRepository: Repository<Permission>,
+    @InjectRepository(UserRole)
+    private readonly userRoleRepository: Repository<UserRole>,
   ) {}
 
   /**
@@ -30,6 +33,8 @@ export class RoleService {
   async findAll(tenantId?: number): Promise<Role[]> {
     const query = this.roleRepository
       .createQueryBuilder('role')
+      .leftJoinAndSelect('role.rolePermissions', 'rolePermissions')
+      .leftJoinAndSelect('rolePermissions.permission', 'permission')
       .where('role.tenantId = :tenantId OR role.tenantId IS NULL', {
         tenantId,
       });
@@ -135,19 +140,29 @@ export class RoleService {
       throw new NotFoundException('One or more permissions not found');
     }
 
-    // Create role-permission links (ignore duplicates)
-    for (const permissionId of permissionIds) {
-      const existing = await this.rolePermissionRepository.findOne({
-        where: { roleId, permissionId },
-      });
+    // 1. Get current permissions
+    const currentRolePermissions = await this.rolePermissionRepository.find({
+      where: { roleId },
+    });
+    const currentIds = currentRolePermissions.map((rp) => rp.permissionId);
 
-      if (!existing) {
-        const rolePermission = this.rolePermissionRepository.create({
-          roleId,
-          permissionId,
-        });
-        await this.rolePermissionRepository.save(rolePermission);
-      }
+    // 2. Identify permissions to remove (in DB but not in new list)
+    const idsToRemove = currentIds.filter((id) => !permissionIds.includes(id));
+    if (idsToRemove.length > 0) {
+      await this.rolePermissionRepository.delete({
+        roleId,
+        permissionId: In(idsToRemove),
+      });
+    }
+
+    // 3. Identify permissions to add (in new list but not in DB)
+    const idsToAdd = permissionIds.filter((id) => !currentIds.includes(id));
+    for (const permissionId of idsToAdd) {
+      const rolePermission = this.rolePermissionRepository.create({
+        roleId,
+        permissionId,
+      });
+      await this.rolePermissionRepository.save(rolePermission);
     }
 
     return this.findOne(roleId, tenantId);
@@ -192,16 +207,16 @@ export class RoleService {
 
     // Create user-role links (ignore duplicates)
     for (const userId of userIds) {
-      const existing = await this.roleRepository.manager
-        .getRepository('UserRole')
-        .findOne({
-          where: { userId, roleId },
-        });
+      const existing = await this.userRoleRepository.findOne({
+        where: { userId, roleId },
+      });
 
       if (!existing) {
-        await this.roleRepository.manager
-          .getRepository('UserRole')
-          .save({ userId, roleId });
+        const userRole = this.userRoleRepository.create({
+          userId,
+          roleId,
+        });
+        await this.userRoleRepository.save(userRole);
       }
     }
 
@@ -223,7 +238,7 @@ export class RoleService {
   ): Promise<void> {
     await this.findOne(roleId, tenantId); // Verify role exists and belongs to tenant
 
-    await this.roleRepository.manager.getRepository('UserRole').delete({
+    await this.userRoleRepository.delete({
       roleId,
       userId,
     });

--- a/api.orchestra.com/src/modules/system/users/user.controller.ts
+++ b/api.orchestra.com/src/modules/system/users/user.controller.ts
@@ -26,7 +26,9 @@ import { CursorPaginationDto } from '../../../common/dto/cursor-pagination.dto';
 import { User } from '../../../entities/system/user.entity';
 import { PaginatedResult } from '@/types';
 import { AuthenticatedGuard } from '@/guards/authenticated.guard';
+import { PermissionsGuard } from '@/guards/permissions.guard';
 import { RolesGuard } from '@/guards/roles.guard';
+import { RequirePermissions } from '@/decorators/require-permissions.decorator';
 import { Roles } from '@/decorators/roles.decorator';
 
 interface AuthenticatedRequest extends Request {
@@ -35,7 +37,7 @@ interface AuthenticatedRequest extends Request {
 
 @ApiTags('Users')
 @ApiBearerAuth()
-@UseGuards(AuthenticatedGuard, RolesGuard)
+@UseGuards(AuthenticatedGuard, PermissionsGuard)
 @Controller('users')
 export class UserController {
   constructor(private readonly userService: UserService) {}
@@ -44,7 +46,7 @@ export class UserController {
    * List users for the current tenant.
    */
   @Get()
-  @Roles('ADMIN')
+  @RequirePermissions('system.user.view')
   @ApiOperation({ summary: 'List users for the current tenant' })
   @ApiResponse({ status: 200, description: 'Return paginated users.' })
   async findAll(
@@ -58,7 +60,7 @@ export class UserController {
    * Create a user for the current tenant.
    */
   @Post()
-  @Roles('ADMIN')
+  @RequirePermissions('system.user.manage')
   @ApiOperation({ summary: 'Create a user for the current tenant' })
   @ApiResponse({
     status: 201,
@@ -77,7 +79,7 @@ export class UserController {
    * Get a user by ID within the current tenant.
    */
   @Get(':id')
-  @Roles('ADMIN')
+  @RequirePermissions('system.user.view')
   @ApiOperation({ summary: 'Get a user by ID' })
   @ApiResponse({ status: 200, description: 'Return the user.' })
   async findOne(
@@ -91,7 +93,7 @@ export class UserController {
    * Update a user within the current tenant.
    */
   @Patch(':id')
-  @Roles('ADMIN')
+  @RequirePermissions('system.user.manage')
   @ApiOperation({ summary: 'Update a user' })
   @ApiResponse({ status: 200, description: 'User updated successfully.' })
   async update(
@@ -106,7 +108,7 @@ export class UserController {
    * Remove a user within the current tenant.
    */
   @Delete(':id')
-  @Roles('ADMIN')
+  @RequirePermissions('system.user.manage')
   @ApiOperation({ summary: 'Remove a user' })
   @ApiResponse({ status: 200, description: 'User removed successfully.' })
   async remove(
@@ -118,10 +120,11 @@ export class UserController {
 
   /**
    * List users for a specific tenant.
-   * Restricted to SUPER_ADMIN or tenant admins (future).
+   * Restricted to SUPER_ADMIN only.
    */
   @Get('tenant/:tenantId')
-  @Roles('SUPER_ADMIN' /* , 'ADMIN' future */)
+  @UseGuards(RolesGuard)
+  @Roles('SUPER_ADMIN')
   @ApiOperation({ summary: 'List users for a specific tenant' })
   @ApiResponse({ status: 200, description: 'Return paginated users.' })
   async findAllForTenant(
@@ -133,9 +136,11 @@ export class UserController {
 
   /**
    * Create a user for a specific tenant.
+   * Restricted to SUPER_ADMIN only.
    */
   @Post('tenant/:tenantId')
-  @Roles('SUPER_ADMIN' /* , 'ADMIN' future */)
+  @UseGuards(RolesGuard)
+  @Roles('SUPER_ADMIN')
   @ApiOperation({ summary: 'Create a user for a specific tenant' })
   @ApiResponse({
     status: 201,

--- a/api.orchestra.com/src/modules/system/users/user.module.ts
+++ b/api.orchestra.com/src/modules/system/users/user.module.ts
@@ -4,9 +4,14 @@ import { UserController } from './user.controller';
 import { UserService } from './user.service';
 import { User } from '../../../entities/system/user.entity';
 import { Tenant } from '../../../entities/system/tenant.entity';
+import { UserRole } from '../../../entities/system/user-role.entity';
+import { PermissionModule } from '@/modules/system/permissions/permission.module';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([User, Tenant])],
+  imports: [
+    TypeOrmModule.forFeature([User, Tenant, UserRole]),
+    PermissionModule,
+  ],
   controllers: [UserController],
   providers: [UserService],
   exports: [UserService],

--- a/docs/walkthroughs/RBAC-Full-Testing-Guide.md
+++ b/docs/walkthroughs/RBAC-Full-Testing-Guide.md
@@ -1,0 +1,90 @@
+# 🛡️ RBAC Implementation Testing Walkthrough
+
+This document provides a step-by-step guide to verify the complete RBAC (Role-Based Access Control) system, covering **Management UI**, **Batch Operations**, and the **Enforcement Layer**.
+
+---
+
+## 🏗️ Pre-test Setup
+1.  Ensure both `api.orchestra.com` and `portal.orchestra.com` are running.
+2.  Login as a **Tenant Admin** (User with full permissions).
+
+---
+
+## 🎯 Test 1: Role & Permission Management
+**Goal**: Verify that custom roles can be created and granular permissions assigned via the Accordion UI.
+
+1.  Navigate to **Settings > Roles**.
+2.  Click **"Add Role"**.
+3.  Create a role named `Test Manager` with a description.
+4.  In the Roles table, click the **"Permissions"** button (Settings icon) for the new role.
+5.  **Verify**: The Permission Picker opens as collapsible **Accordions** grouped by module (e.g., HRIS, System).
+6.  **Action**: Expand the HRIS module. Select only `View Employee` using its **checkbox**.
+7.  **Verify**: The accordion header updates to show "1 of X selected".
+8.  **Action**: Click **"Save Permissions"** and ensure the success toast appears.
+9.  **Verify**: Re-open the permissions modal — the HRIS accordion should auto-expand with `View Employee` pre-checked.
+10. **Verify**: The Roles table's "Permissions" badge now shows the updated count (e.g., "1 permissions").
+
+---
+
+## 🎯 Test 2: Batch User Assignment from Roles Page
+**Goal**: Verify that multiple users can be assigned to a role in a single batch operation.
+
+1.  On the **Settings > Roles** page, click the **"Users"** button (Users icon) on the `Test Manager` role.
+2.  **Verify**: A dialog opens showing all users with a **search bar**.
+3.  **Verify**: The header badge shows "0 assigned" (since the role is new).
+4.  **Action**: Use the search bar to filter by name or email.
+5.  **Action**: Select 2+ users using checkboxes, or click **"Select All"**.
+6.  **Verify**: The header dynamically updates to show "X selected to assign".
+7.  **Action**: Click **"Assign X User(s)"** and confirm the success toast.
+8.  **Verify**: Reopen the Users dialog — previously assigned users now show a ✅ green checkmark and **"Assigned"** badge, and their checkboxes are disabled.
+
+---
+
+## 🎯 Test 3: User-Role Assignment from Users Page
+**Goal**: Verify that individual users can be linked to roles from the Users page (complementary to Test 2).
+
+1.  Navigate to **Settings > Users**.
+2.  Find a test user and click **"Roles"** (UserCog icon).
+3.  **Action**: Assign the `Test Manager` role created in Test 1.
+4.  **Verify**: Click "Save Changes" and ensure the list updates.
+
+---
+
+## 🎯 Test 4: UI Gating (The "Shield")
+**Goal**: Verify that buttons hide automatically when permissions are missing.
+
+1.  **Preparation**: Note the permissions of your test user (from Test 2/3, they only have `view` for employees).
+2.  **Action**: Logout and login as that **Test User**.
+3.  Navigate to **Settings > Roles**.
+4.  **Verify**: The **"Add Role"** button should be **HIDDEN**.
+5.  **Verify**: In the table, the **"Permissions"** and **"Users"** action buttons should be **HIDDEN**.
+6.  **Logic**: The page uses `EntityManager` with `system.role.manage` gates, so these buttons should not render.
+
+---
+
+## 🎯 Test 5: Route Protection (The "Guard")
+**Goal**: Verify that unauthorized users are blocked from entire pages and page refreshes don't cause false redirects.
+
+1.  While logged in as the **Test User** (who lacks admin/management rights):
+2.  **Action**: Manually type `http://localhost:3000/users` or `/roles` in the browser bar.
+3.  **Verify**: You should be redirected to `/unauthorized`.
+4.  **Verify**: The "Access Denied" page shows a brand-aligned UI with "Go Back" and "Return Home" buttons.
+5.  **Action**: Login as the **Tenant Admin** again, navigate to `/roles`, then **hard-refresh** the browser (Ctrl+Shift+R).
+6.  **Verify**: You should **NOT** be redirected to `/unauthorized`. The page should load normally after a brief moment.
+
+---
+
+## 🎯 Test 6: "Double-Gating" Foundation
+**Goal**: Technical verification of the code structure.
+
+1.  Open `portal.orchestra.com/components/auth/HasPermission.tsx`.
+2.  **Verify**: The component includes props for both `permission` AND `feature`.
+3.  **Verify**: The component checks `isInitialized` before evaluating permissions (prevents race condition on refresh).
+4.  **Verify**: The logic is ready to handle Tenant Plan restrictions as soon as the backend feature-flagging is live.
+
+---
+
+## 🚩 Troubleshooting
+- **Cache Issues**: If a permission change doesn't reflect immediately, check the RTK Query tags in `rolesApi.ts`. Both `{ type: 'Role', id: roleId }` and `{ type: 'Role', id: 'LIST' }` must be invalidated.
+- **Unauthorized on Refresh**: Ensure `HasPermission.tsx` checks `selectIsInitialized` before evaluating. If the flag is `false`, it should return `null` instead of redirecting.
+- **Database**: Check the `role_permissions` and `user_roles` junction tables to confirm raw data persistence.

--- a/portal.orchestra.com/app/roles/page.tsx
+++ b/portal.orchestra.com/app/roles/page.tsx
@@ -4,7 +4,7 @@ import { useState, useMemo } from 'react';
 import { EntityManager } from "@/components/entity-manager";
 import { columns as baseColumns } from "./column";
 import { roleFormFields } from "./form-fields";
-import { Shield, Settings } from "lucide-react";
+import { Shield, Settings, Users } from "lucide-react";
 import {
   useGetRolesQuery,
   useCreateRoleMutation,
@@ -14,6 +14,7 @@ import {
 } from "@/store/api/rolesApi";
 import { toast } from "sonner";
 import { RoleDetailsPanel } from "@/components/roles/RoleDetailsPanel";
+import { AssignUsersPanel } from "@/components/roles/AssignUsersPanel";
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog";
 import { Button } from "@/components/ui/button";
 import { Column } from "@/components/ui/data-table";
@@ -26,8 +27,17 @@ export default function RolesPage() {
   const [updateRole] = useUpdateRoleMutation();
   const [deleteRole] = useDeleteRoleMutation();
   
-  const [selectedRole, setSelectedRole] = useState<Role | null>(null);
+  const [selectedRoleId, setSelectedRoleId] = useState<number | null>(null);
   const [isPermissionDialogOpen, setIsPermissionDialogOpen] = useState(false);
+  const [isAssignUsersDialogOpen, setIsAssignUsersDialogOpen] = useState(false);
+
+  // Derive the selected role from the live RTK Query cache.
+  // This fixes the stale-state bug: after assignPermissions invalidates the cache
+  // and roles are re-fetched, selectedRole here will immediately reflect the newest data.
+  const selectedRole = useMemo(
+    () => roles.find((r) => r.id === selectedRoleId) ?? null,
+    [roles, selectedRoleId]
+  );
 
   const stats = [
     {
@@ -56,12 +66,12 @@ export default function RolesPage() {
 
   const handleUpdate = async (id: string | number, formData: any) => {
     try {
-      const role = roles.find((r) => r.id === String(id));
+      const role = roles.find((r) => r.id === Number(id));
       if (role?.isSystemRole) {
         toast.error("Cannot modify system roles");
         throw new Error("Cannot modify system roles");
       }
-      await updateRole({ id: String(id), ...formData }).unwrap();
+      await updateRole({ id: Number(id), ...formData }).unwrap();
       toast.success("Role updated successfully");
     } catch (error) {
       toast.error("Failed to update role");
@@ -71,12 +81,12 @@ export default function RolesPage() {
 
   const handleDelete = async (id: string | number) => {
     try {
-      const role = roles.find((r) => r.id === String(id));
+      const role = roles.find((r) => r.id === Number(id));
       if (role?.isSystemRole) {
         toast.error("Cannot delete system roles");
         throw new Error("Cannot delete system roles");
       }
-      await deleteRole(String(id)).unwrap();
+      await deleteRole(Number(id)).unwrap();
       toast.success("Role deleted successfully");
     } catch (error) {
       toast.error("Failed to delete role");
@@ -85,8 +95,13 @@ export default function RolesPage() {
   };
 
   const handleManagePermissions = (role: Role) => {
-    setSelectedRole(role);
+    setSelectedRoleId(role.id);
     setIsPermissionDialogOpen(true);
+  };
+
+  const handleAssignUsers = (role: Role) => {
+    setSelectedRoleId(role.id);
+    setIsAssignUsersDialogOpen(true);
   };
 
   // Add Manage Permissions column
@@ -98,15 +113,26 @@ export default function RolesPage() {
         className: "text-center",
         cell: (item: Role) => (
           <HasPermission permission="system.role.manage">
-            <Button
-              variant="outline"
-              size="sm"
-              className="gap-2"
-              onClick={() => handleManagePermissions(item)}
-            >
-              <Settings className="h-4 w-4" />
-              Permissions
-            </Button>
+            <div className="flex items-center gap-2">
+              <Button
+                variant="outline"
+                size="sm"
+                className="gap-2"
+                onClick={() => handleManagePermissions(item)}
+              >
+                <Settings className="h-4 w-4" />
+                Permissions
+              </Button>
+              <Button
+                variant="outline"
+                size="sm"
+                className="gap-2"
+                onClick={() => handleAssignUsers(item)}
+              >
+                <Users className="h-4 w-4" />
+                Users
+              </Button>
+            </div>
           </HasPermission>
         ),
       },
@@ -145,6 +171,20 @@ export default function RolesPage() {
             <RoleDetailsPanel
               role={selectedRole}
               onClose={() => setIsPermissionDialogOpen(false)}
+            />
+          )}
+        </DialogContent>
+      </Dialog>
+
+      <Dialog open={isAssignUsersDialogOpen} onOpenChange={setIsAssignUsersDialogOpen}>
+        <DialogContent className="max-w-2xl max-h-[80vh] overflow-y-auto">
+          <DialogHeader>
+            <DialogTitle>Assign Users to Role</DialogTitle>
+          </DialogHeader>
+          {selectedRole && (
+            <AssignUsersPanel
+              role={selectedRole}
+              onClose={() => setIsAssignUsersDialogOpen(false)}
             />
           )}
         </DialogContent>

--- a/portal.orchestra.com/app/users/page.tsx
+++ b/portal.orchestra.com/app/users/page.tsx
@@ -26,8 +26,14 @@ export default function UsersPage() {
   const [updateUser] = useUpdateUserMutation();
   const [deleteUser] = useDeleteUserMutation();
 
-  const [selectedUser, setSelectedUser] = useState<User | null>(null);
+  const [selectedUserId, setSelectedUserId] = useState<number | null>(null);
   const [isRoleDialogOpen, setIsRoleDialogOpen] = useState(false);
+
+  // Derive the selected user from the live RTK Query cache.
+  const selectedUser = useMemo(
+    () => users.find((u) => u.id === selectedUserId) ?? null,
+    [users, selectedUserId]
+  );
 
   const stats = [
     {
@@ -75,7 +81,7 @@ export default function UsersPage() {
   };
 
   const handleManageRoles = (user: User) => {
-    setSelectedUser(user);
+    setSelectedUserId(user.id);
     setIsRoleDialogOpen(true);
   };
 

--- a/portal.orchestra.com/components/auth/HasPermission.tsx
+++ b/portal.orchestra.com/components/auth/HasPermission.tsx
@@ -2,7 +2,7 @@
 
 import React, { ReactNode } from 'react';
 import { useSelector } from 'react-redux';
-import { selectUserPermissions, selectIsAuthenticated } from '@/store/slices/authSlice';
+import { selectUserPermissions, selectIsAuthenticated, selectIsInitialized } from '@/store/slices/authSlice';
 import { useRouter } from 'next/navigation';
 
 interface HasPermissionProps {
@@ -49,8 +49,15 @@ export function HasPermission({
 }: HasPermissionProps) {
   const router = useRouter();
   const isAuthenticated = useSelector(selectIsAuthenticated);
+  const isInitialized = useSelector(selectIsInitialized);
   const userPermissions = useSelector(selectUserPermissions);
   
+  // Wait for the AuthInit /auth/me call to complete before evaluating permissions.
+  // Without this, full-page refreshes instantly fail because Redux starts empty.
+  if (!isInitialized) {
+    return null; // Or a subtle loading spinner if preferred
+  }
+
   // TODO: Add selectTenantFeatures to authSlice once plan/modules are synchronized from backend
   // For now, we focus on permission gating as the primary shield
   const hasFeatureAccess = true; // Placeholder for future feature-gating logic

--- a/portal.orchestra.com/components/roles/AssignUsersPanel.tsx
+++ b/portal.orchestra.com/components/roles/AssignUsersPanel.tsx
@@ -1,0 +1,236 @@
+'use client';
+
+import { useState, useMemo } from 'react';
+import { useGetUsersQuery, User } from '@/store/api/usersApi';
+import { useAssignUsersMutation, Role } from '@/store/api/rolesApi';
+import { Checkbox } from '@/components/ui/checkbox';
+import { Label } from '@/components/ui/label';
+import { Button } from '@/components/ui/button';
+import { Badge } from '@/components/ui/badge';
+import { Input } from '@/components/ui/input';
+import { toast } from 'sonner';
+import { Loader2, Search, Users, UserPlus, CheckCircle2 } from 'lucide-react';
+
+interface AssignUsersPanelProps {
+  role: Role;
+  onClose?: () => void;
+}
+
+export function AssignUsersPanel({ role, onClose }: AssignUsersPanelProps) {
+  const { data: users = [], isLoading: isLoadingUsers } = useGetUsersQuery();
+  const [assignUsers, { isLoading: isAssigning }] = useAssignUsersMutation();
+
+  const [selectedUserIds, setSelectedUserIds] = useState<number[]>([]);
+  const [searchQuery, setSearchQuery] = useState('');
+
+  // Determine which user IDs are already assigned to this role
+  const alreadyAssignedUserIds = useMemo(() => {
+    return users
+      .filter((user) =>
+        user.userRoles?.some((ur) => ur.role && ur.role.id === role.id)
+      )
+      .map((user) => user.id);
+  }, [users, role.id]);
+
+  // Filter users by search query
+  const filteredUsers = useMemo(() => {
+    if (!searchQuery.trim()) return users;
+    const query = searchQuery.toLowerCase();
+    return users.filter(
+      (user) =>
+        user.email.toLowerCase().includes(query) ||
+        (user.firstName && user.firstName.toLowerCase().includes(query)) ||
+        (user.lastName && user.lastName.toLowerCase().includes(query))
+    );
+  }, [users, searchQuery]);
+
+  // Users that can be assigned (not already assigned)
+  const assignableUsers = useMemo(
+    () => filteredUsers.filter((u) => !alreadyAssignedUserIds.includes(u.id)),
+    [filteredUsers, alreadyAssignedUserIds]
+  );
+
+  const handleToggle = (userId: number) => {
+    setSelectedUserIds((prev) =>
+      prev.includes(userId)
+        ? prev.filter((id) => id !== userId)
+        : [...prev, userId]
+    );
+  };
+
+  const handleSelectAll = () => {
+    const assignableIds = assignableUsers.map((u) => u.id);
+    const allSelected = assignableIds.every((id) => selectedUserIds.includes(id));
+
+    if (allSelected) {
+      setSelectedUserIds((prev) =>
+        prev.filter((id) => !assignableIds.includes(id))
+      );
+    } else {
+      setSelectedUserIds((prev) => {
+        const newIds = assignableIds.filter((id) => !prev.includes(id));
+        return [...prev, ...newIds];
+      });
+    }
+  };
+
+  const handleSave = async () => {
+    if (selectedUserIds.length === 0) return;
+
+    try {
+      await assignUsers({
+        roleId: role.id,
+        userIds: selectedUserIds,
+      }).unwrap();
+      toast.success(`${selectedUserIds.length} user(s) assigned to "${role.name}" successfully`);
+      setSelectedUserIds([]);
+      onClose?.();
+    } catch (error) {
+      toast.error('Failed to assign users');
+    }
+  };
+
+  const allAssignableSelected =
+    assignableUsers.length > 0 &&
+    assignableUsers.every((u) => selectedUserIds.includes(u.id));
+
+  if (isLoadingUsers) {
+    return (
+      <div className="flex items-center justify-center p-8">
+        <Loader2 className="h-8 w-8 animate-spin text-muted-foreground" />
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-4">
+      {/* Header info */}
+      <div>
+        <h3 className="text-lg font-semibold">{role.name}</h3>
+        <p className="text-sm text-muted-foreground">{role.description}</p>
+        <div className="flex items-center gap-3 mt-2">
+          <Badge variant="outline" className="gap-1.5">
+            <Users className="h-3 w-3" />
+            {alreadyAssignedUserIds.length} assigned
+          </Badge>
+          {selectedUserIds.length > 0 && (
+            <Badge className="gap-1.5 bg-primary">
+              <UserPlus className="h-3 w-3" />
+              {selectedUserIds.length} selected to assign
+            </Badge>
+          )}
+        </div>
+      </div>
+
+      {/* Search and Select All */}
+      <div className="flex items-center gap-3">
+        <div className="relative flex-1">
+          <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground" />
+          <Input
+            placeholder="Search users by name or email..."
+            value={searchQuery}
+            onChange={(e) => setSearchQuery(e.target.value)}
+            className="pl-9"
+          />
+        </div>
+        <Button
+          variant="outline"
+          size="sm"
+          className="shrink-0 h-9"
+          onClick={handleSelectAll}
+          disabled={assignableUsers.length === 0}
+        >
+          {allAssignableSelected ? 'Deselect All' : 'Select All'}
+        </Button>
+      </div>
+
+      {/* User list */}
+      <div className="border rounded-lg max-h-[400px] overflow-y-auto divide-y">
+        {filteredUsers.length === 0 ? (
+          <div className="flex flex-col items-center justify-center py-8 text-muted-foreground">
+            <Users className="h-8 w-8 mb-2" />
+            <p className="text-sm">No users found</p>
+          </div>
+        ) : (
+          filteredUsers.map((user) => {
+            const isAlreadyAssigned = alreadyAssignedUserIds.includes(user.id);
+            const isSelected = selectedUserIds.includes(user.id);
+            const displayName =
+              user.firstName || user.lastName
+                ? `${user.firstName || ''} ${user.lastName || ''}`.trim()
+                : user.email;
+
+            return (
+              <Label
+                key={user.id}
+                htmlFor={`user-assign-${user.id}`}
+                className={`flex items-center gap-3 px-4 py-3 transition-colors ${
+                  isAlreadyAssigned
+                    ? 'opacity-60 cursor-default bg-muted/30'
+                    : isSelected
+                    ? 'bg-primary/5 cursor-pointer'
+                    : 'hover:bg-muted/40 cursor-pointer'
+                }`}
+              >
+                {isAlreadyAssigned ? (
+                  <CheckCircle2 className="h-4 w-4 text-emerald-500 shrink-0" />
+                ) : (
+                  <Checkbox
+                    id={`user-assign-${user.id}`}
+                    checked={isSelected}
+                    onCheckedChange={() => handleToggle(user.id)}
+                    className="shrink-0 data-[state=checked]:bg-primary data-[state=checked]:text-primary-foreground"
+                  />
+                )}
+                <div className="flex-1 min-w-0">
+                  <div className="flex items-center gap-2">
+                    <span className="text-sm font-medium truncate">
+                      {displayName}
+                    </span>
+                    {isAlreadyAssigned && (
+                      <Badge
+                        variant="outline"
+                        className="text-[10px] bg-emerald-50 text-emerald-700 border-emerald-200 dark:bg-emerald-950 dark:text-emerald-300 dark:border-emerald-800"
+                      >
+                        Assigned
+                      </Badge>
+                    )}
+                    <Badge
+                      variant="outline"
+                      className={`text-[10px] ${
+                        user.status === 'ACTIVE'
+                          ? 'bg-sky-50 text-sky-700 border-sky-200'
+                          : 'bg-gray-100 text-gray-500 border-gray-200'
+                      }`}
+                    >
+                      {user.status}
+                    </Badge>
+                  </div>
+                  <p className="text-xs text-muted-foreground truncate">
+                    {user.email}
+                  </p>
+                </div>
+              </Label>
+            );
+          })
+        )}
+      </div>
+
+      {/* Actions */}
+      <div className="flex justify-end gap-2 pt-2">
+        {onClose && (
+          <Button variant="outline" onClick={onClose}>
+            Cancel
+          </Button>
+        )}
+        <Button
+          onClick={handleSave}
+          disabled={selectedUserIds.length === 0 || isAssigning}
+        >
+          {isAssigning && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+          Assign {selectedUserIds.length > 0 ? `${selectedUserIds.length} User(s)` : 'Users'}
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/portal.orchestra.com/components/roles/PermissionPicker.tsx
+++ b/portal.orchestra.com/components/roles/PermissionPicker.tsx
@@ -1,16 +1,61 @@
-'use client';
-
-import { useState } from 'react';
 import { Permission } from '@/store/api/rolesApi';
 import { Checkbox } from '@/components/ui/checkbox';
 import { Label } from '@/components/ui/label';
 import { Button } from '@/components/ui/button';
-import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Badge } from '@/components/ui/badge';
+import {
+  Accordion,
+  AccordionContent,
+  AccordionItem,
+  AccordionTrigger,
+} from '@/components/ui/accordion';
 
 interface PermissionPickerProps {
   permissions: Permission[];
   selectedPermissionIds: number[];
   onChange: (permissionIds: number[]) => void;
+}
+
+// Converts a snake_case/kebab-case technical string to Title Case.
+// e.g. "employee_profile" -> "Employee Profile", "hris" -> "HRIS"
+function toTitleCase(str: string): string {
+  const ACRONYMS = new Set(['hris', 'crm', 'erp', 'pos', 'api', 'ui', 'id']);
+  return str
+    .split(/[_\-\s]+/)
+    .map((word) =>
+      ACRONYMS.has(word.toLowerCase())
+        ? word.toUpperCase()
+        : word.charAt(0).toUpperCase() + word.slice(1).toLowerCase()
+    )
+    .join(' ');
+}
+
+// Returns a human-readable label for a permission, e.g.:
+// resource="employee", action="view" -> "View Employee"
+function formatPermissionLabel(resource: string, action: string): string {
+  return `${toTitleCase(action)} ${toTitleCase(resource)}`;
+}
+
+// Returns Tailwind classes for a badge based on the action type.
+function getActionBadgeClasses(action: string): string {
+  switch (action.toLowerCase()) {
+    case 'create':
+      return 'bg-emerald-100 text-emerald-700 border-emerald-200 dark:bg-emerald-950 dark:text-emerald-300 dark:border-emerald-800';
+    case 'update':
+    case 'edit':
+      return 'bg-amber-100 text-amber-700 border-amber-200 dark:bg-amber-950 dark:text-amber-300 dark:border-amber-800';
+    case 'delete':
+    case 'remove':
+      return 'bg-rose-100 text-rose-700 border-rose-200 dark:bg-rose-950 dark:text-rose-300 dark:border-rose-800';
+    case 'manage':
+    case 'admin':
+      return 'bg-purple-100 text-purple-700 border-purple-200 dark:bg-purple-950 dark:text-purple-300 dark:border-purple-800';
+    case 'view':
+    case 'read':
+      return 'bg-sky-100 text-sky-700 border-sky-200 dark:bg-sky-950 dark:text-sky-300 dark:border-sky-800';
+    default:
+      return 'bg-muted text-muted-foreground border-border';
+  }
 }
 
 export function PermissionPicker({
@@ -34,7 +79,13 @@ export function PermissionPicker({
     onChange(newSelected);
   };
 
-  const handleSelectAllModule = (module: string) => {
+  const handleSelectAllModule = (
+    module: string,
+    e: React.MouseEvent<HTMLButtonElement>
+  ) => {
+    e.stopPropagation(); // Prevent Accordion from toggling
+    e.preventDefault();
+
     const modulePermissions = groupedPermissions[module];
     const modulePermissionIds = modulePermissions.map((p) => p.id);
     const allSelected = modulePermissionIds.every((id) =>
@@ -42,76 +93,150 @@ export function PermissionPicker({
     );
 
     if (allSelected) {
-      // Deselect all from this module
       onChange(
         selectedPermissionIds.filter((id) => !modulePermissionIds.includes(id))
       );
     } else {
-      // Select all from this module
       const newSelected = [
         ...selectedPermissionIds,
-        ...modulePermissionIds.filter((id) => !selectedPermissionIds.includes(id)),
+        ...modulePermissionIds.filter(
+          (id) => !selectedPermissionIds.includes(id)
+        ),
       ];
       onChange(newSelected);
     }
   };
 
+  // Build an array of module names where some or all permissions are selected
+  // so the accordion opens them by default and they are visible.
+  const getDefaultValue = () => {
+    const openModules: string[] = [];
+    Object.entries(groupedPermissions).forEach(([module, modulePermissions]) => {
+      const modulePermissionIds = modulePermissions.map((p) => p.id);
+      const someSelected = modulePermissionIds.some((id) =>
+        selectedPermissionIds.includes(id)
+      );
+      if (someSelected) {
+        openModules.push(module);
+      }
+    });
+    // Default to opening everything if nothing is selected (brand new role)
+    if (openModules.length === 0) {
+      return Object.keys(groupedPermissions);
+    }
+    return openModules;
+  };
+
   return (
     <div className="space-y-4">
-      {Object.entries(groupedPermissions).map(([module, modulePermissions]) => {
-        const modulePermissionIds = modulePermissions.map((p) => p.id);
-        const allSelected = modulePermissionIds.every((id) =>
-          selectedPermissionIds.includes(id)
-        );
-        const someSelected = modulePermissionIds.some((id) =>
-          selectedPermissionIds.includes(id)
-        );
+      <Accordion
+        type="multiple"
+        defaultValue={getDefaultValue()}
+        className="w-full space-y-4"
+      >
+        {Object.entries(groupedPermissions).map(([module, modulePermissions]) => {
+          const modulePermissionIds = modulePermissions.map((p) => p.id);
+          const allSelected = modulePermissionIds.every((id) =>
+            selectedPermissionIds.includes(id)
+          );
+          const someSelected =
+            !allSelected &&
+            modulePermissionIds.some((id) => selectedPermissionIds.includes(id));
+          const selectedCount = modulePermissionIds.filter((id) =>
+            selectedPermissionIds.includes(id)
+          ).length;
 
-        return (
-          <Card key={module}>
-            <CardHeader className="pb-3">
-              <div className="flex items-center justify-between">
-                <CardTitle className="text-base font-medium uppercase">
-                  {module}
-                </CardTitle>
-                <Button
-                  variant="outline"
-                  size="sm"
-                  onClick={() => handleSelectAllModule(module)}
-                >
-                  {allSelected ? 'Deselect All' : 'Select All'}
-                </Button>
-              </div>
-            </CardHeader>
-            <CardContent>
-              <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
-                {modulePermissions.map((permission) => (
-                  <div key={permission.id} className="flex items-start space-x-2">
-                    <Checkbox
-                      id={`permission-${permission.id}`}
-                      checked={selectedPermissionIds.includes(permission.id)}
-                      onCheckedChange={() => handleToggle(permission.id)}
-                    />
-                    <div className="grid gap-1.5 leading-none">
-                      <Label
-                        htmlFor={`permission-${permission.id}`}
-                        className="text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70 cursor-pointer"
+          return (
+            <AccordionItem
+              value={module}
+              key={module}
+              className="border rounded-lg bg-card px-4"
+            >
+              <AccordionTrigger className="hover:no-underline py-4">
+                <div className="flex items-center justify-between w-full pr-4">
+                  <div className="flex flex-wrap items-center gap-3">
+                    <span className="text-sm font-semibold tracking-wide uppercase text-foreground">
+                      {toTitleCase(module)}
+                    </span>
+                    {someSelected && (
+                      <Badge
+                        variant="outline"
+                        className="text-xs font-normal text-muted-foreground"
                       >
-                        {permission.resource}.{permission.action}
-                      </Label>
-                      {permission.description && (
-                        <p className="text-xs text-muted-foreground">
-                          {permission.description}
-                        </p>
-                      )}
-                    </div>
+                        {selectedCount} of {modulePermissions.length} selected
+                      </Badge>
+                    )}
+                    {allSelected && (
+                      <Badge
+                        variant="outline"
+                        className="text-xs font-normal bg-primary/10 text-primary border-primary/30"
+                      >
+                        All selected
+                      </Badge>
+                    )}
                   </div>
-                ))}
-              </div>
-            </CardContent>
-          </Card>
-        );
-      })}
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    className="h-7 text-xs shrink-0 z-10 hover:bg-muted"
+                    onClick={(e) => handleSelectAllModule(module, e)}
+                  >
+                    {allSelected ? 'Deselect All' : 'Select All'}
+                  </Button>
+                </div>
+              </AccordionTrigger>
+              <AccordionContent className="pt-2 pb-4">
+                <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
+                  {modulePermissions.map((permission) => {
+                    const isChecked = selectedPermissionIds.includes(
+                      permission.id
+                    );
+                    return (
+                      <Label
+                        key={permission.id}
+                        htmlFor={`permission-${permission.id}`}
+                        className={`flex items-start gap-3 rounded-lg border p-3 cursor-pointer transition-all ${
+                          isChecked
+                            ? 'bg-primary/5 border-primary/30 ring-1 ring-primary/20'
+                            : 'bg-muted/10 border-border hover:bg-muted/40 hover:border-primary/20'
+                        }`}
+                      >
+                        <Checkbox
+                          id={`permission-${permission.id}`}
+                          checked={isChecked}
+                          onCheckedChange={() => handleToggle(permission.id)}
+                          className="mt-0.5 shrink-0 data-[state=checked]:bg-primary data-[state=checked]:text-primary-foreground"
+                        />
+                        <div className="grid gap-1.5 leading-none min-w-0">
+                          <span className="text-sm font-medium leading-none select-none">
+                            {formatPermissionLabel(
+                              permission.resource,
+                              permission.action
+                            )}
+                          </span>
+                          <div className="flex items-center gap-2 flex-wrap">
+                            <Badge
+                              variant="outline"
+                              className={`text-[10px] font-medium px-1.5 py-0 border ${getActionBadgeClasses(permission.action)}`}
+                            >
+                              {toTitleCase(permission.action)}
+                            </Badge>
+                            {permission.description && (
+                              <p className="text-xs text-muted-foreground/80 truncate">
+                                {permission.description}
+                              </p>
+                            )}
+                          </div>
+                        </div>
+                      </Label>
+                    );
+                  })}
+                </div>
+              </AccordionContent>
+            </AccordionItem>
+          );
+        })}
+      </Accordion>
     </div>
   );
 }

--- a/portal.orchestra.com/components/roles/RoleDetailsPanel.tsx
+++ b/portal.orchestra.com/components/roles/RoleDetailsPanel.tsx
@@ -4,8 +4,9 @@ import { useState, useEffect } from 'react';
 import { Role, Permission, useGetPermissionsQuery, useAssignPermissionsMutation } from '@/store/api/rolesApi';
 import { PermissionPicker } from './PermissionPicker';
 import { Button } from '@/components/ui/button';
+import { Badge } from '@/components/ui/badge';
 import { toast } from 'sonner';
-import { Loader2 } from 'lucide-react';
+import { Loader2, ShieldCheck } from 'lucide-react';
 
 interface RoleDetailsPanelProps {
   role: Role;
@@ -91,14 +92,31 @@ export function RoleDetailsPanel({ role, onClose }: RoleDetailsPanelProps) {
       )}
 
       {role.isSystemRole && (
-        <div className="bg-muted p-4 rounded-lg">
-          <h4 className="font-medium mb-2">Current Permissions</h4>
-          <div className="space-y-1">
-            {role.rolePermissions?.map((rp) => (
-              <div key={rp.permission.id} className="text-sm">
-                {rp.permission.module}.{rp.permission.resource}.{rp.permission.action}
-              </div>
-            ))}
+      <div className="bg-muted/40 border rounded-lg p-4">
+          <div className="flex items-center gap-2 mb-3">
+            <ShieldCheck className="h-4 w-4 text-muted-foreground" />
+            <h4 className="text-sm font-semibold">System Permissions (Read-only)</h4>
+          </div>
+          <div className="flex flex-wrap gap-2">
+            {role.rolePermissions?.map((rp) => {
+              const action = rp.permission.action.toLowerCase();
+              const badgeClass =
+                action === 'create' ? 'bg-emerald-100 text-emerald-700 border-emerald-200' :
+                action === 'update' || action === 'edit' ? 'bg-amber-100 text-amber-700 border-amber-200' :
+                action === 'delete' || action === 'remove' ? 'bg-rose-100 text-rose-700 border-rose-200' :
+                action === 'manage' || action === 'admin' ? 'bg-purple-100 text-purple-700 border-purple-200' :
+                'bg-sky-100 text-sky-700 border-sky-200';
+              const label = `${rp.permission.action.charAt(0).toUpperCase() + rp.permission.action.slice(1)} ${rp.permission.resource.charAt(0).toUpperCase() + rp.permission.resource.slice(1)}`;
+              return (
+                <Badge
+                  key={rp.permission.id}
+                  variant="outline"
+                  className={`text-xs font-medium border ${badgeClass}`}
+                >
+                  {label}
+                </Badge>
+              );
+            })}
           </div>
         </div>
       )}

--- a/portal.orchestra.com/components/ui/accordion.tsx
+++ b/portal.orchestra.com/components/ui/accordion.tsx
@@ -1,0 +1,66 @@
+"use client"
+
+import * as React from "react"
+import { ChevronDownIcon } from "lucide-react"
+import { Accordion as AccordionPrimitive } from "radix-ui"
+
+import { cn } from "@/lib/utils"
+
+function Accordion({
+  ...props
+}: React.ComponentProps<typeof AccordionPrimitive.Root>) {
+  return <AccordionPrimitive.Root data-slot="accordion" {...props} />
+}
+
+function AccordionItem({
+  className,
+  ...props
+}: React.ComponentProps<typeof AccordionPrimitive.Item>) {
+  return (
+    <AccordionPrimitive.Item
+      data-slot="accordion-item"
+      className={cn("border-b last:border-b-0", className)}
+      {...props}
+    />
+  )
+}
+
+function AccordionTrigger({
+  className,
+  children,
+  ...props
+}: React.ComponentProps<typeof AccordionPrimitive.Trigger>) {
+  return (
+    <AccordionPrimitive.Header className="flex">
+      <AccordionPrimitive.Trigger
+        data-slot="accordion-trigger"
+        className={cn(
+          "flex flex-1 items-start justify-between gap-4 rounded-md py-4 text-left text-sm font-medium transition-all outline-none hover:underline focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:pointer-events-none disabled:opacity-50 [&[data-state=open]>svg]:rotate-180",
+          className
+        )}
+        {...props}
+      >
+        {children}
+        <ChevronDownIcon className="pointer-events-none size-4 shrink-0 translate-y-0.5 text-muted-foreground transition-transform duration-200" />
+      </AccordionPrimitive.Trigger>
+    </AccordionPrimitive.Header>
+  )
+}
+
+function AccordionContent({
+  className,
+  children,
+  ...props
+}: React.ComponentProps<typeof AccordionPrimitive.Content>) {
+  return (
+    <AccordionPrimitive.Content
+      data-slot="accordion-content"
+      className="overflow-hidden text-sm data-[state=closed]:animate-accordion-up data-[state=open]:animate-accordion-down"
+      {...props}
+    >
+      <div className={cn("pt-0 pb-4", className)}>{children}</div>
+    </AccordionPrimitive.Content>
+  )
+}
+
+export { Accordion, AccordionItem, AccordionTrigger, AccordionContent }

--- a/portal.orchestra.com/components/users/UserRolesManager.tsx
+++ b/portal.orchestra.com/components/users/UserRolesManager.tsx
@@ -19,7 +19,7 @@ export function UserRolesManager({ user, onClose }: UserRolesManagerProps) {
   const [assignUsers] = useAssignUsersMutation();
   const [removeUserFromRole] = useRemoveUserFromRoleMutation();
   
-  const [selectedRoleIds, setSelectedRoleIds] = useState<string[]>([]);
+  const [selectedRoleIds, setSelectedRoleIds] = useState<number[]>([]);
   const [isSubmitting, setIsSubmitting] = useState(false);
 
   // Initialize selected roles from user
@@ -28,11 +28,11 @@ export function UserRolesManager({ user, onClose }: UserRolesManagerProps) {
       const roleIds = user.userRoles
         .map((ur) => ur.role?.id)
         .filter((id): id is number => id !== undefined);
-      setSelectedRoleIds(roleIds.map(String));
+      setSelectedRoleIds(roleIds);
     }
   }, [user]);
 
-  const handleToggle = (roleId: string) => {
+  const handleToggle = (roleId: number) => {
     setSelectedRoleIds((prev) =>
       prev.includes(roleId)
         ? prev.filter((id) => id !== roleId)
@@ -43,7 +43,7 @@ export function UserRolesManager({ user, onClose }: UserRolesManagerProps) {
   const handleSave = async () => {
     setIsSubmitting(true);
     try {
-      const currentRoleIds = user.userRoles?.map((ur) => String(ur.role?.id)) || [];
+      const currentRoleIds = user.userRoles?.map((ur) => ur.role?.id).filter((id): id is number => id !== undefined) || [];
       
       // Roles to add
       const rolesToAdd = selectedRoleIds.filter((id) => !currentRoleIds.includes(id));
@@ -77,7 +77,7 @@ export function UserRolesManager({ user, onClose }: UserRolesManagerProps) {
   };
 
   const hasChanges = () => {
-    const currentIds = user.userRoles?.map((ur) => String(ur.role?.id)) || [];
+    const currentIds = user.userRoles?.map((ur) => ur.role?.id).filter((id): id is number => id !== undefined) || [];
     if (currentIds.length !== selectedRoleIds.length) return true;
     return !currentIds.every((id) => selectedRoleIds.includes(id));
   };

--- a/portal.orchestra.com/package.json
+++ b/portal.orchestra.com/package.json
@@ -25,6 +25,7 @@
     "lucide-react": "^0.563.0",
     "next": "16.1.3",
     "next-themes": "^0.4.6",
+    "radix-ui": "^1.4.3",
     "react": "19.2.3",
     "react-dom": "19.2.3",
     "react-redux": "^9.2.0",

--- a/portal.orchestra.com/pnpm-lock.yaml
+++ b/portal.orchestra.com/pnpm-lock.yaml
@@ -56,6 +56,9 @@ importers:
       next-themes:
         specifier: ^0.4.6
         version: 0.4.6(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      radix-ui:
+        specifier: ^1.4.3
+        version: 1.4.3(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       react:
         specifier: 19.2.3
         version: 19.2.3
@@ -483,8 +486,73 @@ packages:
   '@radix-ui/primitive@1.1.3':
     resolution: {integrity: sha512-JTF99U/6XIjCBo0wqkU5sK10glYe27MRRsfwoiq5zzOEZLHU3A3KCMa5X/azekYRCJ0HlwI0crAXS/5dEHTzDg==}
 
+  '@radix-ui/react-accessible-icon@1.1.7':
+    resolution: {integrity: sha512-XM+E4WXl0OqUJFovy6GjmxxFyx9opfCAIUku4dlKRd5YEPqt4kALOkQOp0Of6reHuUkJuiPBEc5k0o4z4lTC8A==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-accordion@1.2.12':
+    resolution: {integrity: sha512-T4nygeh9YE9dLRPhAHSeOZi7HBXo+0kYIPJXayZfvWOWA0+n3dESrZbjfDPUABkUNym6Hd+f2IR113To8D2GPA==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-alert-dialog@1.1.15':
+    resolution: {integrity: sha512-oTVLkEw5GpdRe29BqJ0LSDFWI3qu0vR1M0mUkOQWDIUnY/QIkLpgDMWuKxP94c2NAC2LGcgVhG1ImF3jkZ5wXw==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   '@radix-ui/react-arrow@1.1.7':
     resolution: {integrity: sha512-F+M1tLhO+mlQaOWspE8Wstg+z6PwxwRd8oQ8IXceWz92kfAmalTRf0EjrouQeo7QssEPfCn05B4Ihs1K9WQ/7w==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-aspect-ratio@1.1.7':
+    resolution: {integrity: sha512-Yq6lvO9HQyPwev1onK1daHCHqXVLzPhSVjmsNjCa2Zcxy2f7uJD2itDtxknv6FzAKCwD1qQkeVDmX/cev13n/g==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-avatar@1.1.10':
+    resolution: {integrity: sha512-V8piFfWapM5OmNCXTzVQY+E1rDa53zY+MQ4Y7356v4fFz6vqCyUtIz2rUD44ZEdwg78/jKmMJHj07+C/Z/rcog==}
     peerDependencies:
       '@types/react': '*'
       '@types/react-dom': '*'
@@ -557,6 +625,19 @@ packages:
       '@types/react':
         optional: true
 
+  '@radix-ui/react-context-menu@2.2.16':
+    resolution: {integrity: sha512-O8morBEW+HsVG28gYDZPTrT9UUovQUlJue5YO836tiTJhuIWBm/zQHc7j388sHWtdH/xUZurK9olD2+pcqx5ww==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   '@radix-ui/react-context@1.1.2':
     resolution: {integrity: sha512-jCi/QKUM2r1Ju5a3J64TH2A5SpKAgh0LpknyqdQ4m6DCV0xJ2HG1xARRwNGPQfi1SLdLWZ1OJz6F4OMBBNiGJA==}
     peerDependencies:
@@ -610,6 +691,19 @@ packages:
       '@types/react-dom':
         optional: true
 
+  '@radix-ui/react-dropdown-menu@2.1.16':
+    resolution: {integrity: sha512-1PLGQEynI/3OX/ftV54COn+3Sud/Mn8vALg2rWnBLnRaGtJDduNW/22XjlGgPdpcIbiQxjKtb7BkcjP00nqfJw==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   '@radix-ui/react-focus-guards@1.1.3':
     resolution: {integrity: sha512-0rFg/Rj2Q62NCm62jZw0QX7a3sz6QCQU0LpZdNrJX8byRGaGVTqbrW9jAoIAHyMQqsNpeZ81YgSizOt5WXq0Pw==}
     peerDependencies:
@@ -632,6 +726,32 @@ packages:
       '@types/react-dom':
         optional: true
 
+  '@radix-ui/react-form@0.1.8':
+    resolution: {integrity: sha512-QM70k4Zwjttifr5a4sZFts9fn8FzHYvQ5PiB19O2HsYibaHSVt9fH9rzB0XZo/YcM+b7t/p7lYCT/F5eOeF5yQ==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-hover-card@1.1.15':
+    resolution: {integrity: sha512-qgTkjNT1CfKMoP0rcasmlH2r1DAiYicWsDsufxl940sT2wHNEWWv6FMWIQXWhVdmC1d/HYfbhQx60KYyAtKxjg==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   '@radix-ui/react-id@1.1.1':
     resolution: {integrity: sha512-kGkGegYIdQsOb4XjsfM97rXsiHaBwco+hFI66oO4s9LU+PLAC5oJ7khdOVFxkhsmlbpUqDAvXw11CluXP+jkHg==}
     peerDependencies:
@@ -641,8 +761,99 @@ packages:
       '@types/react':
         optional: true
 
+  '@radix-ui/react-label@2.1.7':
+    resolution: {integrity: sha512-YT1GqPSL8kJn20djelMX7/cTRp/Y9w5IZHvfxQTVHrOqa2yMl7i/UfMqKRU5V7mEyKTrUVgJXhNQPVCG8PBLoQ==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   '@radix-ui/react-label@2.1.8':
     resolution: {integrity: sha512-FmXs37I6hSBVDlO4y764TNz1rLgKwjJMQ0EGte6F3Cb3f4bIuHB/iLa/8I9VKkmOy+gNHq8rql3j686ACVV21A==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-menu@2.1.16':
+    resolution: {integrity: sha512-72F2T+PLlphrqLcAotYPp0uJMr5SjP5SL01wfEspJbru5Zs5vQaSHb4VB3ZMJPimgHHCHG7gMOeOB9H3Hdmtxg==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-menubar@1.1.16':
+    resolution: {integrity: sha512-EB1FktTz5xRRi2Er974AUQZWg2yVBb1yjip38/lgwtCVRd3a+maUoGHN/xs9Yv8SY8QwbSEb+YrxGadVWbEutA==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-navigation-menu@1.2.14':
+    resolution: {integrity: sha512-YB9mTFQvCOAQMHU+C/jVl96WmuWeltyUEpRJJky51huhds5W2FQr1J8D/16sQlf0ozxkPK8uF3niQMdUwZPv5w==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-one-time-password-field@0.1.8':
+    resolution: {integrity: sha512-ycS4rbwURavDPVjCb5iS3aG4lURFDILi6sKI/WITUMZ13gMmn/xGjpLoqBAalhJaDk8I3UbCM5GzKHrnzwHbvg==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-password-toggle-field@0.1.3':
+    resolution: {integrity: sha512-/UuCrDBWravcaMix4TdT+qlNdVwOM1Nck9kWx/vafXsdfj1ChfhOdfi3cy9SGBpWgTXwYCuboT/oYpJy3clqfw==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-popover@1.1.15':
+    resolution: {integrity: sha512-kr0X2+6Yy/vJzLYJUPCZEc8SfQcf+1COFoAqauJm74umQhta9M7lNJHP7QQS3vkvcGLQUbWpMzwrXYwrYztHKA==}
     peerDependencies:
       '@types/react': '*'
       '@types/react-dom': '*'
@@ -719,8 +930,47 @@ packages:
       '@types/react-dom':
         optional: true
 
+  '@radix-ui/react-progress@1.1.7':
+    resolution: {integrity: sha512-vPdg/tF6YC/ynuBIJlk1mm7Le0VgW6ub6J2UWnTQ7/D23KXcPI1qy+0vBkgKgd38RCMJavBXpB83HPNFMTb0Fg==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-radio-group@1.3.8':
+    resolution: {integrity: sha512-VBKYIYImA5zsxACdisNQ3BjCBfmbGH3kQlnFVqlWU4tXwjy7cGX8ta80BcrO+WJXIn5iBylEH3K6ZTlee//lgQ==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   '@radix-ui/react-roving-focus@1.1.11':
     resolution: {integrity: sha512-7A6S9jSgm/S+7MdtNDSb+IU859vQqJ/QAtcYQcfFC6W8RS4IxIZDldLR0xqCFZ6DCyrQLjLPsxtTNch5jVA4lA==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-scroll-area@1.2.10':
+    resolution: {integrity: sha512-tAXIa1g3sM5CGpVT0uIbUx/U3Gs5N8T52IICuCtObaos1S8fzsrPXG5WObkQN3S6NVl6wKgPhAIiBGbWnvc97A==}
     peerDependencies:
       '@types/react': '*'
       '@types/react-dom': '*'
@@ -745,8 +995,34 @@ packages:
       '@types/react-dom':
         optional: true
 
+  '@radix-ui/react-separator@1.1.7':
+    resolution: {integrity: sha512-0HEb8R9E8A+jZjvmFCy/J4xhbXy3TV+9XSnGJ3KvTtjlIUy/YQ/p6UYZvi7YbeoeXdyU9+Y3scizK6hkY37baA==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   '@radix-ui/react-separator@1.1.8':
     resolution: {integrity: sha512-sDvqVY4itsKwwSMEe0jtKgfTh+72Sy3gPmQpjqcQneqQ4PFmr/1I0YA+2/puilhggCe2gJcx5EBAYFkWkdpa5g==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-slider@1.3.6':
+    resolution: {integrity: sha512-JPYb1GuM1bxfjMRlNLE+BcmBC8onfCi60Blk7OBqi2MLTFdS+8401U4uFjnwkOr49BLmXxLC6JHkvAsx5OJvHw==}
     peerDependencies:
       '@types/react': '*'
       '@types/react-dom': '*'
@@ -776,8 +1052,73 @@ packages:
       '@types/react':
         optional: true
 
+  '@radix-ui/react-switch@1.2.6':
+    resolution: {integrity: sha512-bByzr1+ep1zk4VubeEVViV592vu2lHE2BZY5OnzehZqOOgogN80+mNtCqPkhn2gklJqOpxWgPoYTSnhBCqpOXQ==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   '@radix-ui/react-tabs@1.1.13':
     resolution: {integrity: sha512-7xdcatg7/U+7+Udyoj2zodtI9H/IIopqo+YOIcZOq1nJwXWBZ9p8xiu5llXlekDbZkca79a/fozEYQXIA4sW6A==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-toast@1.2.15':
+    resolution: {integrity: sha512-3OSz3TacUWy4WtOXV38DggwxoqJK4+eDkNMl5Z/MJZaoUPaP4/9lf81xXMe1I2ReTAptverZUpbPY4wWwWyL5g==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-toggle-group@1.1.11':
+    resolution: {integrity: sha512-5umnS0T8JQzQT6HbPyO7Hh9dgd82NmS36DQr+X/YJ9ctFNCiiQd6IJAYYZ33LUwm8M+taCz5t2ui29fHZc4Y6Q==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-toggle@1.1.10':
+    resolution: {integrity: sha512-lS1odchhFTeZv3xwHH31YPObmJn8gOg7Lq12inrr0+BH/l3Tsq32VfjqH1oh80ARM3mlkfMic15n0kg4sD1poQ==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-toolbar@1.1.11':
+    resolution: {integrity: sha512-4ol06/1bLoFu1nwUqzdD4Y5RZ9oDdKeiHIsntug54Hcr1pgaHiPqHFEaXI1IFP/EsOfROQZ8Mig9VTIRza6Tjg==}
     peerDependencies:
       '@types/react': '*'
       '@types/react-dom': '*'
@@ -2161,6 +2502,19 @@ packages:
   queue-microtask@1.2.3:
     resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
 
+  radix-ui@1.4.3:
+    resolution: {integrity: sha512-aWizCQiyeAenIdUbqEpXgRA1ya65P13NKn/W8rWkcN0OPkRDxdBVLWnIEDsS2RpwCK2nobI7oMUSmexzTDyAmA==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   react-dom@19.2.3:
     resolution: {integrity: sha512-yELu4WmLPw5Mr/lmeEpox5rw3RETacE++JgHqQzd2dg+YbJuat3jH4ingc+WPZhxaoFzdv9y33G+F7Nl5O0GBg==}
     peerDependencies:
@@ -2905,9 +3259,71 @@ snapshots:
 
   '@radix-ui/primitive@1.1.3': {}
 
+  '@radix-ui/react-accessible-icon@1.1.7(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
+    dependencies:
+      '@radix-ui/react-visually-hidden': 1.2.3(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      react: 19.2.3
+      react-dom: 19.2.3(react@19.2.3)
+    optionalDependencies:
+      '@types/react': 19.2.8
+      '@types/react-dom': 19.2.3(@types/react@19.2.8)
+
+  '@radix-ui/react-accordion@1.2.12(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-collapsible': 1.1.12(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@radix-ui/react-collection': 1.1.7(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.8)(react@19.2.3)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.8)(react@19.2.3)
+      '@radix-ui/react-direction': 1.1.1(@types/react@19.2.8)(react@19.2.3)
+      '@radix-ui/react-id': 1.1.1(@types/react@19.2.8)(react@19.2.3)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.8)(react@19.2.3)
+      react: 19.2.3
+      react-dom: 19.2.3(react@19.2.3)
+    optionalDependencies:
+      '@types/react': 19.2.8
+      '@types/react-dom': 19.2.3(@types/react@19.2.8)
+
+  '@radix-ui/react-alert-dialog@1.1.15(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.8)(react@19.2.3)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.8)(react@19.2.3)
+      '@radix-ui/react-dialog': 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@radix-ui/react-slot': 1.2.3(@types/react@19.2.8)(react@19.2.3)
+      react: 19.2.3
+      react-dom: 19.2.3(react@19.2.3)
+    optionalDependencies:
+      '@types/react': 19.2.8
+      '@types/react-dom': 19.2.3(@types/react@19.2.8)
+
   '@radix-ui/react-arrow@1.1.7(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
     dependencies:
       '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      react: 19.2.3
+      react-dom: 19.2.3(react@19.2.3)
+    optionalDependencies:
+      '@types/react': 19.2.8
+      '@types/react-dom': 19.2.3(@types/react@19.2.8)
+
+  '@radix-ui/react-aspect-ratio@1.1.7(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
+    dependencies:
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      react: 19.2.3
+      react-dom: 19.2.3(react@19.2.3)
+    optionalDependencies:
+      '@types/react': 19.2.8
+      '@types/react-dom': 19.2.3(@types/react@19.2.8)
+
+  '@radix-ui/react-avatar@1.1.10(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
+    dependencies:
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.8)(react@19.2.3)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.2.8)(react@19.2.3)
+      '@radix-ui/react-use-is-hydrated': 0.1.0(@types/react@19.2.8)(react@19.2.3)
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.8)(react@19.2.3)
       react: 19.2.3
       react-dom: 19.2.3(react@19.2.3)
     optionalDependencies:
@@ -2977,6 +3393,20 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.8
 
+  '@radix-ui/react-context-menu@2.2.16(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.8)(react@19.2.3)
+      '@radix-ui/react-menu': 2.1.16(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.2.8)(react@19.2.3)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.8)(react@19.2.3)
+      react: 19.2.3
+      react-dom: 19.2.3(react@19.2.3)
+    optionalDependencies:
+      '@types/react': 19.2.8
+      '@types/react-dom': 19.2.3(@types/react@19.2.8)
+
   '@radix-ui/react-context@1.1.2(@types/react@19.2.8)(react@19.2.3)':
     dependencies:
       react: 19.2.3
@@ -3030,6 +3460,21 @@ snapshots:
       '@types/react': 19.2.8
       '@types/react-dom': 19.2.3(@types/react@19.2.8)
 
+  '@radix-ui/react-dropdown-menu@2.1.16(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.8)(react@19.2.3)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.8)(react@19.2.3)
+      '@radix-ui/react-id': 1.1.1(@types/react@19.2.8)(react@19.2.3)
+      '@radix-ui/react-menu': 2.1.16(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.8)(react@19.2.3)
+      react: 19.2.3
+      react-dom: 19.2.3(react@19.2.3)
+    optionalDependencies:
+      '@types/react': 19.2.8
+      '@types/react-dom': 19.2.3(@types/react@19.2.8)
+
   '@radix-ui/react-focus-guards@1.1.3(@types/react@19.2.8)(react@19.2.3)':
     dependencies:
       react: 19.2.3
@@ -3047,6 +3492,37 @@ snapshots:
       '@types/react': 19.2.8
       '@types/react-dom': 19.2.3(@types/react@19.2.8)
 
+  '@radix-ui/react-form@0.1.8(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.8)(react@19.2.3)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.8)(react@19.2.3)
+      '@radix-ui/react-id': 1.1.1(@types/react@19.2.8)(react@19.2.3)
+      '@radix-ui/react-label': 2.1.7(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      react: 19.2.3
+      react-dom: 19.2.3(react@19.2.3)
+    optionalDependencies:
+      '@types/react': 19.2.8
+      '@types/react-dom': 19.2.3(@types/react@19.2.8)
+
+  '@radix-ui/react-hover-card@1.1.15(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.8)(react@19.2.3)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.8)(react@19.2.3)
+      '@radix-ui/react-dismissable-layer': 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@radix-ui/react-popper': 1.2.8(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@radix-ui/react-portal': 1.1.9(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@radix-ui/react-presence': 1.1.5(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.8)(react@19.2.3)
+      react: 19.2.3
+      react-dom: 19.2.3(react@19.2.3)
+    optionalDependencies:
+      '@types/react': 19.2.8
+      '@types/react-dom': 19.2.3(@types/react@19.2.8)
+
   '@radix-ui/react-id@1.1.1(@types/react@19.2.8)(react@19.2.3)':
     dependencies:
       '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.8)(react@19.2.3)
@@ -3054,11 +3530,145 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.8
 
+  '@radix-ui/react-label@2.1.7(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
+    dependencies:
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      react: 19.2.3
+      react-dom: 19.2.3(react@19.2.3)
+    optionalDependencies:
+      '@types/react': 19.2.8
+      '@types/react-dom': 19.2.3(@types/react@19.2.8)
+
   '@radix-ui/react-label@2.1.8(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
     dependencies:
       '@radix-ui/react-primitive': 2.1.4(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       react: 19.2.3
       react-dom: 19.2.3(react@19.2.3)
+    optionalDependencies:
+      '@types/react': 19.2.8
+      '@types/react-dom': 19.2.3(@types/react@19.2.8)
+
+  '@radix-ui/react-menu@2.1.16(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-collection': 1.1.7(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.8)(react@19.2.3)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.8)(react@19.2.3)
+      '@radix-ui/react-direction': 1.1.1(@types/react@19.2.8)(react@19.2.3)
+      '@radix-ui/react-dismissable-layer': 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@radix-ui/react-focus-guards': 1.1.3(@types/react@19.2.8)(react@19.2.3)
+      '@radix-ui/react-focus-scope': 1.1.7(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@radix-ui/react-id': 1.1.1(@types/react@19.2.8)(react@19.2.3)
+      '@radix-ui/react-popper': 1.2.8(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@radix-ui/react-portal': 1.1.9(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@radix-ui/react-presence': 1.1.5(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@radix-ui/react-roving-focus': 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@radix-ui/react-slot': 1.2.3(@types/react@19.2.8)(react@19.2.3)
+      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.2.8)(react@19.2.3)
+      aria-hidden: 1.2.6
+      react: 19.2.3
+      react-dom: 19.2.3(react@19.2.3)
+      react-remove-scroll: 2.7.2(@types/react@19.2.8)(react@19.2.3)
+    optionalDependencies:
+      '@types/react': 19.2.8
+      '@types/react-dom': 19.2.3(@types/react@19.2.8)
+
+  '@radix-ui/react-menubar@1.1.16(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-collection': 1.1.7(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.8)(react@19.2.3)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.8)(react@19.2.3)
+      '@radix-ui/react-direction': 1.1.1(@types/react@19.2.8)(react@19.2.3)
+      '@radix-ui/react-id': 1.1.1(@types/react@19.2.8)(react@19.2.3)
+      '@radix-ui/react-menu': 2.1.16(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@radix-ui/react-roving-focus': 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.8)(react@19.2.3)
+      react: 19.2.3
+      react-dom: 19.2.3(react@19.2.3)
+    optionalDependencies:
+      '@types/react': 19.2.8
+      '@types/react-dom': 19.2.3(@types/react@19.2.8)
+
+  '@radix-ui/react-navigation-menu@1.2.14(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-collection': 1.1.7(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.8)(react@19.2.3)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.8)(react@19.2.3)
+      '@radix-ui/react-direction': 1.1.1(@types/react@19.2.8)(react@19.2.3)
+      '@radix-ui/react-dismissable-layer': 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@radix-ui/react-id': 1.1.1(@types/react@19.2.8)(react@19.2.3)
+      '@radix-ui/react-presence': 1.1.5(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.2.8)(react@19.2.3)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.8)(react@19.2.3)
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.8)(react@19.2.3)
+      '@radix-ui/react-use-previous': 1.1.1(@types/react@19.2.8)(react@19.2.3)
+      '@radix-ui/react-visually-hidden': 1.2.3(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      react: 19.2.3
+      react-dom: 19.2.3(react@19.2.3)
+    optionalDependencies:
+      '@types/react': 19.2.8
+      '@types/react-dom': 19.2.3(@types/react@19.2.8)
+
+  '@radix-ui/react-one-time-password-field@0.1.8(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
+    dependencies:
+      '@radix-ui/number': 1.1.1
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-collection': 1.1.7(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.8)(react@19.2.3)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.8)(react@19.2.3)
+      '@radix-ui/react-direction': 1.1.1(@types/react@19.2.8)(react@19.2.3)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@radix-ui/react-roving-focus': 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.8)(react@19.2.3)
+      '@radix-ui/react-use-effect-event': 0.0.2(@types/react@19.2.8)(react@19.2.3)
+      '@radix-ui/react-use-is-hydrated': 0.1.0(@types/react@19.2.8)(react@19.2.3)
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.8)(react@19.2.3)
+      react: 19.2.3
+      react-dom: 19.2.3(react@19.2.3)
+    optionalDependencies:
+      '@types/react': 19.2.8
+      '@types/react-dom': 19.2.3(@types/react@19.2.8)
+
+  '@radix-ui/react-password-toggle-field@0.1.3(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.8)(react@19.2.3)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.8)(react@19.2.3)
+      '@radix-ui/react-id': 1.1.1(@types/react@19.2.8)(react@19.2.3)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.8)(react@19.2.3)
+      '@radix-ui/react-use-effect-event': 0.0.2(@types/react@19.2.8)(react@19.2.3)
+      '@radix-ui/react-use-is-hydrated': 0.1.0(@types/react@19.2.8)(react@19.2.3)
+      react: 19.2.3
+      react-dom: 19.2.3(react@19.2.3)
+    optionalDependencies:
+      '@types/react': 19.2.8
+      '@types/react-dom': 19.2.3(@types/react@19.2.8)
+
+  '@radix-ui/react-popover@1.1.15(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.8)(react@19.2.3)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.8)(react@19.2.3)
+      '@radix-ui/react-dismissable-layer': 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@radix-ui/react-focus-guards': 1.1.3(@types/react@19.2.8)(react@19.2.3)
+      '@radix-ui/react-focus-scope': 1.1.7(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@radix-ui/react-id': 1.1.1(@types/react@19.2.8)(react@19.2.3)
+      '@radix-ui/react-popper': 1.2.8(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@radix-ui/react-portal': 1.1.9(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@radix-ui/react-presence': 1.1.5(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@radix-ui/react-slot': 1.2.3(@types/react@19.2.8)(react@19.2.3)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.8)(react@19.2.3)
+      aria-hidden: 1.2.6
+      react: 19.2.3
+      react-dom: 19.2.3(react@19.2.3)
+      react-remove-scroll: 2.7.2(@types/react@19.2.8)(react@19.2.3)
     optionalDependencies:
       '@types/react': 19.2.8
       '@types/react-dom': 19.2.3(@types/react@19.2.8)
@@ -3119,6 +3729,34 @@ snapshots:
       '@types/react': 19.2.8
       '@types/react-dom': 19.2.3(@types/react@19.2.8)
 
+  '@radix-ui/react-progress@1.1.7(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
+    dependencies:
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.8)(react@19.2.3)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      react: 19.2.3
+      react-dom: 19.2.3(react@19.2.3)
+    optionalDependencies:
+      '@types/react': 19.2.8
+      '@types/react-dom': 19.2.3(@types/react@19.2.8)
+
+  '@radix-ui/react-radio-group@1.3.8(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.8)(react@19.2.3)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.8)(react@19.2.3)
+      '@radix-ui/react-direction': 1.1.1(@types/react@19.2.8)(react@19.2.3)
+      '@radix-ui/react-presence': 1.1.5(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@radix-ui/react-roving-focus': 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.8)(react@19.2.3)
+      '@radix-ui/react-use-previous': 1.1.1(@types/react@19.2.8)(react@19.2.3)
+      '@radix-ui/react-use-size': 1.1.1(@types/react@19.2.8)(react@19.2.3)
+      react: 19.2.3
+      react-dom: 19.2.3(react@19.2.3)
+    optionalDependencies:
+      '@types/react': 19.2.8
+      '@types/react-dom': 19.2.3(@types/react@19.2.8)
+
   '@radix-ui/react-roving-focus@1.1.11(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
     dependencies:
       '@radix-ui/primitive': 1.1.3
@@ -3130,6 +3768,23 @@ snapshots:
       '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.2.8)(react@19.2.3)
       '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.8)(react@19.2.3)
+      react: 19.2.3
+      react-dom: 19.2.3(react@19.2.3)
+    optionalDependencies:
+      '@types/react': 19.2.8
+      '@types/react-dom': 19.2.3(@types/react@19.2.8)
+
+  '@radix-ui/react-scroll-area@1.2.10(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
+    dependencies:
+      '@radix-ui/number': 1.1.1
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.8)(react@19.2.3)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.8)(react@19.2.3)
+      '@radix-ui/react-direction': 1.1.1(@types/react@19.2.8)(react@19.2.3)
+      '@radix-ui/react-presence': 1.1.5(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.2.8)(react@19.2.3)
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.8)(react@19.2.3)
       react: 19.2.3
       react-dom: 19.2.3(react@19.2.3)
     optionalDependencies:
@@ -3165,9 +3820,37 @@ snapshots:
       '@types/react': 19.2.8
       '@types/react-dom': 19.2.3(@types/react@19.2.8)
 
+  '@radix-ui/react-separator@1.1.7(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
+    dependencies:
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      react: 19.2.3
+      react-dom: 19.2.3(react@19.2.3)
+    optionalDependencies:
+      '@types/react': 19.2.8
+      '@types/react-dom': 19.2.3(@types/react@19.2.8)
+
   '@radix-ui/react-separator@1.1.8(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
     dependencies:
       '@radix-ui/react-primitive': 2.1.4(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      react: 19.2.3
+      react-dom: 19.2.3(react@19.2.3)
+    optionalDependencies:
+      '@types/react': 19.2.8
+      '@types/react-dom': 19.2.3(@types/react@19.2.8)
+
+  '@radix-ui/react-slider@1.3.6(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
+    dependencies:
+      '@radix-ui/number': 1.1.1
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-collection': 1.1.7(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.8)(react@19.2.3)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.8)(react@19.2.3)
+      '@radix-ui/react-direction': 1.1.1(@types/react@19.2.8)(react@19.2.3)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.8)(react@19.2.3)
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.8)(react@19.2.3)
+      '@radix-ui/react-use-previous': 1.1.1(@types/react@19.2.8)(react@19.2.3)
+      '@radix-ui/react-use-size': 1.1.1(@types/react@19.2.8)(react@19.2.3)
       react: 19.2.3
       react-dom: 19.2.3(react@19.2.3)
     optionalDependencies:
@@ -3188,6 +3871,21 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.8
 
+  '@radix-ui/react-switch@1.2.6(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.8)(react@19.2.3)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.8)(react@19.2.3)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.8)(react@19.2.3)
+      '@radix-ui/react-use-previous': 1.1.1(@types/react@19.2.8)(react@19.2.3)
+      '@radix-ui/react-use-size': 1.1.1(@types/react@19.2.8)(react@19.2.3)
+      react: 19.2.3
+      react-dom: 19.2.3(react@19.2.3)
+    optionalDependencies:
+      '@types/react': 19.2.8
+      '@types/react-dom': 19.2.3(@types/react@19.2.8)
+
   '@radix-ui/react-tabs@1.1.13(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
     dependencies:
       '@radix-ui/primitive': 1.1.3
@@ -3198,6 +3896,67 @@ snapshots:
       '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       '@radix-ui/react-roving-focus': 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.8)(react@19.2.3)
+      react: 19.2.3
+      react-dom: 19.2.3(react@19.2.3)
+    optionalDependencies:
+      '@types/react': 19.2.8
+      '@types/react-dom': 19.2.3(@types/react@19.2.8)
+
+  '@radix-ui/react-toast@1.2.15(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-collection': 1.1.7(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.8)(react@19.2.3)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.8)(react@19.2.3)
+      '@radix-ui/react-dismissable-layer': 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@radix-ui/react-portal': 1.1.9(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@radix-ui/react-presence': 1.1.5(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.2.8)(react@19.2.3)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.8)(react@19.2.3)
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.8)(react@19.2.3)
+      '@radix-ui/react-visually-hidden': 1.2.3(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      react: 19.2.3
+      react-dom: 19.2.3(react@19.2.3)
+    optionalDependencies:
+      '@types/react': 19.2.8
+      '@types/react-dom': 19.2.3(@types/react@19.2.8)
+
+  '@radix-ui/react-toggle-group@1.1.11(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.8)(react@19.2.3)
+      '@radix-ui/react-direction': 1.1.1(@types/react@19.2.8)(react@19.2.3)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@radix-ui/react-roving-focus': 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@radix-ui/react-toggle': 1.1.10(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.8)(react@19.2.3)
+      react: 19.2.3
+      react-dom: 19.2.3(react@19.2.3)
+    optionalDependencies:
+      '@types/react': 19.2.8
+      '@types/react-dom': 19.2.3(@types/react@19.2.8)
+
+  '@radix-ui/react-toggle@1.1.10(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.8)(react@19.2.3)
+      react: 19.2.3
+      react-dom: 19.2.3(react@19.2.3)
+    optionalDependencies:
+      '@types/react': 19.2.8
+      '@types/react-dom': 19.2.3(@types/react@19.2.8)
+
+  '@radix-ui/react-toolbar@1.1.11(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.8)(react@19.2.3)
+      '@radix-ui/react-direction': 1.1.1(@types/react@19.2.8)(react@19.2.3)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@radix-ui/react-roving-focus': 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@radix-ui/react-separator': 1.1.7(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@radix-ui/react-toggle-group': 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       react: 19.2.3
       react-dom: 19.2.3(react@19.2.3)
     optionalDependencies:
@@ -4681,6 +5440,69 @@ snapshots:
   punycode@2.3.1: {}
 
   queue-microtask@1.2.3: {}
+
+  radix-ui@1.4.3(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3):
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-accessible-icon': 1.1.7(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@radix-ui/react-accordion': 1.2.12(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@radix-ui/react-alert-dialog': 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@radix-ui/react-arrow': 1.1.7(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@radix-ui/react-aspect-ratio': 1.1.7(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@radix-ui/react-avatar': 1.1.10(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@radix-ui/react-checkbox': 1.3.3(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@radix-ui/react-collapsible': 1.1.12(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@radix-ui/react-collection': 1.1.7(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.8)(react@19.2.3)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.8)(react@19.2.3)
+      '@radix-ui/react-context-menu': 2.2.16(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@radix-ui/react-dialog': 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@radix-ui/react-direction': 1.1.1(@types/react@19.2.8)(react@19.2.3)
+      '@radix-ui/react-dismissable-layer': 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@radix-ui/react-dropdown-menu': 2.1.16(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@radix-ui/react-focus-guards': 1.1.3(@types/react@19.2.8)(react@19.2.3)
+      '@radix-ui/react-focus-scope': 1.1.7(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@radix-ui/react-form': 0.1.8(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@radix-ui/react-hover-card': 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@radix-ui/react-label': 2.1.7(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@radix-ui/react-menu': 2.1.16(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@radix-ui/react-menubar': 1.1.16(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@radix-ui/react-navigation-menu': 1.2.14(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@radix-ui/react-one-time-password-field': 0.1.8(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@radix-ui/react-password-toggle-field': 0.1.3(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@radix-ui/react-popover': 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@radix-ui/react-popper': 1.2.8(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@radix-ui/react-portal': 1.1.9(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@radix-ui/react-presence': 1.1.5(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@radix-ui/react-progress': 1.1.7(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@radix-ui/react-radio-group': 1.3.8(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@radix-ui/react-roving-focus': 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@radix-ui/react-scroll-area': 1.2.10(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@radix-ui/react-select': 2.2.6(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@radix-ui/react-separator': 1.1.7(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@radix-ui/react-slider': 1.3.6(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@radix-ui/react-slot': 1.2.3(@types/react@19.2.8)(react@19.2.3)
+      '@radix-ui/react-switch': 1.2.6(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@radix-ui/react-tabs': 1.1.13(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@radix-ui/react-toast': 1.2.15(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@radix-ui/react-toggle': 1.1.10(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@radix-ui/react-toggle-group': 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@radix-ui/react-toolbar': 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@radix-ui/react-tooltip': 1.2.8(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.2.8)(react@19.2.3)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.8)(react@19.2.3)
+      '@radix-ui/react-use-effect-event': 0.0.2(@types/react@19.2.8)(react@19.2.3)
+      '@radix-ui/react-use-escape-keydown': 1.1.1(@types/react@19.2.8)(react@19.2.3)
+      '@radix-ui/react-use-is-hydrated': 0.1.0(@types/react@19.2.8)(react@19.2.3)
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.8)(react@19.2.3)
+      '@radix-ui/react-use-size': 1.1.1(@types/react@19.2.8)(react@19.2.3)
+      '@radix-ui/react-visually-hidden': 1.2.3(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      react: 19.2.3
+      react-dom: 19.2.3(react@19.2.3)
+    optionalDependencies:
+      '@types/react': 19.2.8
+      '@types/react-dom': 19.2.3(@types/react@19.2.8)
 
   react-dom@19.2.3(react@19.2.3):
     dependencies:

--- a/portal.orchestra.com/store/api/authApi.ts
+++ b/portal.orchestra.com/store/api/authApi.ts
@@ -1,16 +1,6 @@
-import { createApi, fetchBaseQuery } from '@reduxjs/toolkit/query/react';
+import { baseApi } from './baseApi';
 
-export const authApi = createApi({
-  reducerPath: 'authApi',
-  baseQuery: fetchBaseQuery({
-    baseUrl: process.env.NEXT_PUBLIC_API_URL,
-    prepareHeaders: (headers) => {
-      // Headers can be added here, like authorization tokens if using Bearer
-      return headers;
-    },
-    credentials: 'include',
-  }),
-  tagTypes: ['User'],
+export const authApi = baseApi.injectEndpoints({
   endpoints: (builder) => ({
     login: builder.mutation<any, any>({
       query: (credentials) => ({

--- a/portal.orchestra.com/store/api/baseApi.ts
+++ b/portal.orchestra.com/store/api/baseApi.ts
@@ -1,0 +1,20 @@
+import { createApi, fetchBaseQuery } from '@reduxjs/toolkit/query/react';
+
+/**
+ * Shared base API for all features.
+ * Consolidating to a single API slice allows for cross-feature tag invalidation
+ * (e.g. rolesApi invalidating usersApi tags).
+ */
+export const baseApi = createApi({
+  reducerPath: 'baseApi',
+  baseQuery: fetchBaseQuery({
+    baseUrl: process.env.NEXT_PUBLIC_API_URL,
+    prepareHeaders: (headers) => {
+      // Logic for shared headers (e.g. auth tokens) can be added here
+      return headers;
+    },
+    credentials: 'include',
+  }),
+  tagTypes: ['User', 'Role', 'Permission'],
+  endpoints: () => ({}), // Endpoints will be injected by feature-specific files
+});

--- a/portal.orchestra.com/store/api/rolesApi.ts
+++ b/portal.orchestra.com/store/api/rolesApi.ts
@@ -1,7 +1,7 @@
-import { createApi, fetchBaseQuery } from '@reduxjs/toolkit/query/react';
+import { baseApi } from './baseApi';
 
 export interface Role {
-  id: string;
+  id: number;
   name: string;
   code: string;
   description: string;
@@ -21,17 +21,7 @@ export interface Permission {
   isActive: boolean;
 }
 
-export const rolesApi = createApi({
-  reducerPath: 'rolesApi',
-  baseQuery: fetchBaseQuery({
-    baseUrl: process.env.NEXT_PUBLIC_API_URL,
-    prepareHeaders: (headers) => {
-      // Inherit logic from authApi.ts
-      return headers;
-    },
-    credentials: 'include',
-  }),
-  tagTypes: ['Role', 'Permission', 'User'],
+export const rolesApi = baseApi.injectEndpoints({
   endpoints: (builder) => ({
     getRoles: builder.query<Role[], void>({
       query: () => '/system/roles',
@@ -43,7 +33,7 @@ export const rolesApi = createApi({
             ]
           : [{ type: 'Role', id: 'LIST' }],
     }),
-    getRole: builder.query<Role, string>({
+    getRole: builder.query<Role, number>({
       query: (id) => `/system/roles/${id}`,
       providesTags: (_result, _error, id) => [{ type: 'Role', id }],
     }),
@@ -63,7 +53,7 @@ export const rolesApi = createApi({
       }),
       invalidatesTags: (_result, _error, { id }) => [{ type: 'Role', id }],
     }),
-    deleteRole: builder.mutation<void, string>({
+    deleteRole: builder.mutation<void, number>({
       query: (id) => ({
         url: `/system/roles/${id}`,
         method: 'DELETE',
@@ -74,23 +64,29 @@ export const rolesApi = createApi({
       query: () => '/system/permissions',
       providesTags: [{ type: 'Permission', id: 'LIST' }],
     }),
-    assignPermissions: builder.mutation<Role, { roleId: string; permissionIds: number[] }>({
+    assignPermissions: builder.mutation<Role, { roleId: number; permissionIds: number[] }>({
       query: ({ roleId, permissionIds }) => ({
         url: `/system/roles/${roleId}/permissions`,
         method: 'POST',
         body: { permissionIds },
       }),
-      invalidatesTags: (_result, _error, { roleId }) => [{ type: 'Role', id: roleId }],
+      invalidatesTags: (_result, _error, { roleId }) => [
+        { type: 'Role', id: roleId },
+        { type: 'Role', id: 'LIST' },
+      ],
     }),
-    removePermissions: builder.mutation<Role, { roleId: string; permissionIds: number[] }>({
+    removePermissions: builder.mutation<Role, { roleId: number; permissionIds: number[] }>({
       query: ({ roleId, permissionIds }) => ({
         url: `/system/roles/${roleId}/permissions`,
         method: 'DELETE',
         body: { permissionIds },
       }),
-      invalidatesTags: (_result, _error, { roleId }) => [{ type: 'Role', id: roleId }],
+      invalidatesTags: (_result, _error, { roleId }) => [
+        { type: 'Role', id: roleId },
+        { type: 'Role', id: 'LIST' },
+      ],
     }),
-    assignUsers: builder.mutation<Role, { roleId: string; userIds: number[] }>({
+    assignUsers: builder.mutation<Role, { roleId: number; userIds: number[] }>({
       query: ({ roleId, userIds }) => ({
         url: `/system/roles/${roleId}/users`,
         method: 'POST',
@@ -101,7 +97,7 @@ export const rolesApi = createApi({
         { type: 'User', id: 'LIST' },
       ],
     }),
-    removeUserFromRole: builder.mutation<void, { roleId: string; userId: number }>({
+    removeUserFromRole: builder.mutation<void, { roleId: number; userId: number }>({
       query: ({ roleId, userId }) => ({
         url: `/system/roles/${roleId}/users/${userId}`,
         method: 'DELETE',

--- a/portal.orchestra.com/store/api/usersApi.ts
+++ b/portal.orchestra.com/store/api/usersApi.ts
@@ -1,4 +1,4 @@
-import { createApi, fetchBaseQuery } from '@reduxjs/toolkit/query/react';
+import { baseApi } from './baseApi';
 
 export interface User {
   id: number;
@@ -24,16 +24,7 @@ interface PaginatedResponse<T> {
   };
 }
 
-export const usersApi = createApi({
-  reducerPath: 'usersApi',
-  baseQuery: fetchBaseQuery({
-    baseUrl: process.env.NEXT_PUBLIC_API_URL,
-    prepareHeaders: (headers) => {
-      return headers;
-    },
-    credentials: 'include',
-  }),
-  tagTypes: ['User'],
+export const usersApi = baseApi.injectEndpoints({
   endpoints: (builder) => ({
     getUsers: builder.query<User[], void>({
       query: () => '/users',

--- a/portal.orchestra.com/store/index.ts
+++ b/portal.orchestra.com/store/index.ts
@@ -1,22 +1,16 @@
 import { configureStore } from '@reduxjs/toolkit';
 import { setupListeners } from '@reduxjs/toolkit/query';
-import { authApi } from './api/authApi';
-import { usersApi } from './api/usersApi';
-import { rolesApi } from './api/rolesApi';
+import { baseApi } from './api/baseApi';
 import authReducer from './slices/authSlice';
 
 export const store = configureStore({
   reducer: {
-    [authApi.reducerPath]: authApi.reducer,
-    [usersApi.reducerPath]: usersApi.reducer,
-    [rolesApi.reducerPath]: rolesApi.reducer,
+    [baseApi.reducerPath]: baseApi.reducer,
     auth: authReducer,
   },
   middleware: (getDefaultMiddleware) =>
     getDefaultMiddleware().concat(
-      authApi.middleware,
-      usersApi.middleware,
-      rolesApi.middleware,
+      baseApi.middleware,
     ),
 });
 


### PR DESCRIPTION
# 📝 Pull Request Description

## 🔍 Overview
Completes the RBAC enforcement layer by migrating all tenant-facing API controllers from the legacy role-name guard (`@Roles('ADMIN')` + [RolesGuard](cci:2://file:///c:/Users/ROMEL/Desktop/Romel%20Documents/development/Personal%20Passion/erp-orchestra/api.orchestra.com/src/guards/roles.guard.ts:17:0-82:1)) to the slug-based permission guard (`@RequirePermissions()` + [PermissionsGuard](cci:2://file:///c:/Users/ROMEL/Desktop/Romel%20Documents/development/Personal%20Passion/erp-orchestra/api.orchestra.com/src/guards/permissions.guard.ts:28:0-83:1)). Previously, any non-system-admin user without an `ADMIN` role code received a 403 — even if they had the correct granular permissions assigned. This PR fixes that and enables the full permission-based access control flow end-to-end.

## 🚀 Key Changes
- **[RoleController]**: Replaced `@Roles('ADMIN')` with `@RequirePermissions('system.role.view')` (GET) and `@RequirePermissions('system.role.manage')` (POST/PATCH/DELETE).
- **[PermissionController]**: Replaced `@Roles('ADMIN')` with `@RequirePermissions('system.permission.view')` for listing. The [check](cci:1://file:///c:/Users/ROMEL/Desktop/Romel%20Documents/development/Personal%20Passion/erp-orchestra/api.orchestra.com/src/modules/system/permissions/permission.controller.ts:74:2-83:3) endpoint remains open to any authenticated user.
- **[UserController]**: Replaced `@Roles('ADMIN')` with `@RequirePermissions('system.user.view')` (GET) and `@RequirePermissions('system.user.manage')` (POST/PATCH/DELETE). SUPER_ADMIN-only cross-tenant endpoints remain on [RolesGuard](cci:2://file:///c:/Users/ROMEL/Desktop/Romel%20Documents/development/Personal%20Passion/erp-orchestra/api.orchestra.com/src/guards/roles.guard.ts:17:0-82:1).
- **[RoleModule]**: Added [PermissionModule](cci:2://file:///c:/Users/ROMEL/Desktop/Romel%20Documents/development/Personal%20Passion/erp-orchestra/api.orchestra.com/src/modules/system/permissions/permission.module.ts:8:0-14:32) import for [PermissionsGuard](cci:2://file:///c:/Users/ROMEL/Desktop/Romel%20Documents/development/Personal%20Passion/erp-orchestra/api.orchestra.com/src/guards/permissions.guard.ts:28:0-83:1) DI resolution.
- **[UserModule]**: Added [PermissionModule](cci:2://file:///c:/Users/ROMEL/Desktop/Romel%20Documents/development/Personal%20Passion/erp-orchestra/api.orchestra.com/src/modules/system/permissions/permission.module.ts:8:0-14:32) import for [PermissionsGuard](cci:2://file:///c:/Users/ROMEL/Desktop/Romel%20Documents/development/Personal%20Passion/erp-orchestra/api.orchestra.com/src/guards/permissions.guard.ts:28:0-83:1) DI resolution.

## 🔗 Related Issues/Epics
- Relates to EPIC-RBAC

## 🧪 Testing Performed
- [x] Automated tests passed
- [x] Manual verification completed
- [x] UI/UX checked across multiple screen sizes

### Manual Verification (Full RBAC Testing Guide):
1. ✅ **Role & Permission Management** — Create roles, assign permissions via accordion UI
2. ✅ **Batch User Assignment** — Assign multiple users to roles from Roles page
3. ✅ **User-Role Assignment** — Assign roles to individual users from Users page
4. ✅ **UI Gating** — Buttons/actions hidden when user lacks permissions
5. ✅ **Route Protection** — Unauthorized users redirected to `/unauthorized`
6. ✅ **Double-Gating Foundation** — `HasPermission` component verified with `feature` prop ready for future plan gating

## 📸 Screenshots / Recordings
1. Permission to view roles
<img width="1913" height="861" alt="image" src="https://github.com/user-attachments/assets/24e81320-eaad-450c-8db1-4312e3ba5bcd" />
2. User UI/UX with limited permission
<img width="1913" height="861" alt="image" src="https://github.com/user-attachments/assets/00660bbd-0849-4534-b247-b45ad908d4a4" />
3. 403 on unauthorized page
<img width="1913" height="946" alt="image" src="https://github.com/user-attachments/assets/ca0f8070-6c12-4902-8ba3-f79a46adde67" />


## 🚩 Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
