### PR TITLE
docs: reorganize ERDs, split HRIS epics & update roadmap

### DIFF
--- a/docs/Entity Relationship Diagram/ENTITY-MAPPING.md
+++ b/docs/Entity Relationship Diagram/ENTITY-MAPPING.md
@@ -80,9 +80,24 @@ This table maps NestJS Entity classes to their corresponding database tables and
 | **Operations** | `OpsGoodsReceipt` | `operations.goods_receipts` | Recording incoming warehouse stock. |
 | **Finance** | `FinInvoice` | `finance.invoices` | Billing documents sent to customers. |
 | **Finance** | `FinAccountPayable` | `finance.accounts_payable` | Tracking money owed to vendors. |
+| **HRIS** | `HrisBranch` | `hris.branches` | Physical locations/branches of the company. |
+| **HRIS** | `HrisDepartment` | `hris.departments` | Organizational units within the company. |
+| **HRIS** | `HrisDesignation` | `hris.designations` | Job roles and levels within the company. |
 | **HRIS** | `HrisEmployee` | `hris.employees` | Master data for staff and people. |
-| **HRIS** | `HrisTimeSheet` | `hris.timesheets` | Records of hours worked by employees. |
-| **HRIS** | `HrisPayroll` | `hris.payroll_runs` | Calculated salary and tax records. |
+| **HRIS** | `HrisEmployeeJobHistory` | `hris.employee_job_history` | Historical records of roles, managers, and departments. |
+| **HRIS** | `HrisEmployeeDocument` | `hris.employee_documents` | Uploaded files and documents associated with the employee. |
+| **HRIS** | `HrisTimeEvent` | `hris.time_events` | Raw clock-in/out attendance logs. |
+| **HRIS** | `HrisPayPeriod` | `hris.pay_periods` | Defined periods for payroll and timesheet aggregation. |
+| **HRIS** | `HrisTimeSheet` | `hris.timesheets` | Aggregated attendance records per pay period. |
+| **HRIS** | `HrisTimeSheetDay` | `hris.timesheet_days` | Daily breakdown of regular and overtime hours. |
+| **HRIS** | `HrisTimeSheetAdjustment`| `hris.timesheet_adjustments`| Manual adjustments made to timesheet days. |
+| **HRIS** | `HrisTimeSheetAnomaly` | `hris.timesheet_anomalies` | System-flagged anomalies (e.g., missed clock-outs). |
+| **HRIS** | `HrisEmployeeCompensation`| `hris.employee_compensation`| Base salary, hourly, or daily rates for staff. |
+| **HRIS** | `HrisDeduction` | `hris.deductions` | Recurring or one-time deductions for employees. |
+| **HRIS** | `HrisPayslip` | `hris.payslips` | Generated payment slips per pay period. |
+| **HRIS** | `HrisPayslipItem` | `hris.payslip_items` | Line items within a payslip (earnings, taxes, deductions). |
+| **HRIS** | `HrisLeaveType` | `hris.leave_types` | Configurable leave categories (e.g., Vacation, Sick). |
+| **HRIS** | `HrisLeaveRequest` | `hris.leave_requests` | Applications filed by employees for time off.
 
 ### 3.1 Junction Tables
 

--- a/docs/Entity Relationship Diagram/HRIS-ERD.md
+++ b/docs/Entity Relationship Diagram/HRIS-ERD.md
@@ -1,0 +1,289 @@
+# ERD: HRIS & Employee Management
+
+This diagram represents the database schema for the Human Resources Information System (HRIS) module.
+It illustrates how organizational master data connects to the central `Employee` entity, up through time tracking, leaves, and payroll.
+
+```dbml
+title ERD HRIS (Enterprise Grade)
+
+// We reference these from the 'system' schema to show the connection
+tenants [icon: building, color: gray] {
+  id integer [pk, increment]
+  name varchar(150)
+  note: "Tenant ID (from system schema)"
+}
+
+users [icon: user, color: blue] {
+  id integer [pk, increment]
+  company_id integer
+  email varchar(255)
+  password_hash varchar(255)
+  display_name varchar(150)
+  first_name varchar(100)
+  last_name varchar(100)
+  is_active boolean
+  last_login_at timestamptz
+  note: "System Identity (from system schema)"
+}
+
+// HRIS specific tables
+branches [icon: map-pin, color: orange] {
+  id integer [pk, increment]
+  tenant_id integer [not null, note: "FK to tenants.id"]
+  code varchar(50)
+  name varchar(150) [not null, note: "e.g. 'Main Office', 'Downtown Hub'"]
+  address text
+  contact_number varchar(50)
+  status varchar(20) [note: "Active, Inactive"]
+  created_at timestamptz
+}
+
+departments [icon: briefcase, color: purple] {
+  id integer [pk, increment]
+  tenant_id integer [not null, note: "FK to tenants.id"]
+  code varchar(50) [note: "e.g. 'ENG', 'FIN'"]
+  name varchar(150) [not null, note: "e.g. 'Engineering', 'Finance'"]
+  description text
+  head_employee_id integer [note: "FK to employees.id - Department Head"]
+  created_at timestamptz
+}
+
+designations [icon: award, color: purple] {
+  id integer [pk, increment]
+  tenant_id integer [not null, note: "FK to tenants.id"]
+  code varchar(50) [note: "e.g. 'SDEV', 'AMGR'"]
+  name varchar(150) [not null, note: "e.g. 'Senior Developer', 'Area Manager'"]
+  level integer [note: "Hierarchy/Pay grade level"]
+  description text
+  created_at timestamptz
+}
+
+employees [icon: users, color: green] {
+  id integer [pk, increment]
+  tenant_id integer [not null, note: "FK to tenants.id"]
+  user_id integer [unique, nullable, note: "1-to-1 link to system.users. Null if no portal access yet."]
+  
+  employee_code varchar(50) [unique, not null, note: "e.g. 'EMP-001'"]
+  
+  first_name varchar(100) [not null]
+  last_name varchar(100) [not null]
+  email varchar(255) [unique, not null]
+  phone varchar(50)
+  
+  // Organizational Links
+  branch_id integer [not null, note: "FK to branches"]
+  department_id integer [not null, note: "FK to departments"]
+  designation_id integer [not null, note: "FK to designations"]
+  manager_id integer [nullable, note: "Self-referencing FK to employees for reporting hierarchy"]
+  
+  employment_type varchar(50)
+  
+  hire_date date [not null]
+  terminated_at date
+  
+  status varchar(20) [default: "'Active'", note: "Active, OnLeave, Terminated"]
+  
+  emergency_contact text
+  
+  created_at timestamptz
+  updated_at timestamptz
+}
+
+employee_job_history [icon: clock, color: green] {
+  id integer [pk, increment]
+  employee_id integer
+  branch_id integer
+  department_id integer
+  designation_id integer
+  manager_id integer
+  start_date date
+  end_date date
+  reason text
+}
+
+employee_documents [icon: file-text, color: green] {
+  id integer [pk, increment]
+  employee_id integer
+  document_type varchar(50)
+  file_url text
+  uploaded_at timestamptz
+}
+
+time_events [icon: watch, color: red] {
+  id integer [pk, increment]
+  employee_id integer
+  type varchar(50)
+  source varchar(50)
+  happened_at timestamptz
+  device_id varchar(150)
+  ip_address varchar(80)
+  request_id varchar(100)
+  meta_json text
+}
+
+pay_periods [icon: calendar, color: red] {
+  id integer [pk, increment]
+  tenant_id integer
+  start_date date
+  end_date date
+  status varchar(20)
+  closed_at timestamptz
+  closed_by_user_id integer
+}
+
+timesheets [icon: file-text, color: red] {
+  id integer [pk, increment]
+  employee_id integer
+  pay_period_id integer
+  status varchar(20)
+  generated_at timestamptz
+  reviewed_at timestamptz
+  reviewed_by_user_id integer
+  approved_at timestamptz
+  approved_by_user_id integer
+}
+
+timesheet_days [icon: calendar, color: red] {
+  id integer [pk, increment]
+  timesheet_id integer
+  work_date date
+  regular_minutes integer
+  break_minutes integer
+  overtime_minutes integer
+}
+
+timesheet_adjustments [icon: edit-2, color: red] {
+  id integer [pk, increment]
+  timesheet_day_id integer
+  field varchar(50)
+  mode varchar(50)
+  delta_minutes integer
+  override_minutes integer
+  reason text
+  created_by_user_id integer
+}
+
+timesheet_anomalies [icon: alert-triangle, color: red] {
+  id integer [pk, increment]
+  timesheet_day_id integer
+  code varchar(50)
+  severity varchar(20)
+  message varchar(400)
+}
+
+employee_compensation [icon: dollar-sign, color: yellow] {
+  id integer [pk, increment]
+  employee_id integer
+  type varchar(50)
+  hourly_rate decimal
+  daily_rate decimal
+  monthly_salary decimal
+  effective_from date
+  effective_to date
+}
+
+deductions [icon: minus-circle, color: yellow] {
+  id integer [pk, increment]
+  employee_id integer
+  type varchar(50)
+  label varchar(255)
+  calculation_type varchar(50)
+  amount decimal
+  effective_from date
+  effective_until date
+  is_active boolean
+}
+
+payslips [icon: file-text, color: yellow] {
+  id integer [pk, increment]
+  employee_id integer
+  pay_period_id integer
+  status varchar(20)
+  total_regular_minutes integer
+  total_overtime_minutes integer
+  gross_pay decimal
+  total_deductions decimal
+  net_pay decimal
+  currency varchar(10)
+  generated_by_user_id integer
+  generated_at timestamptz
+}
+
+payslip_items [icon: list, color: yellow] {
+  id integer [pk, increment]
+  payslip_id integer
+  type varchar(50)
+  code varchar(50)
+  label varchar(150)
+  amount decimal
+  meta_json text
+}
+
+leave_types [icon: umbrela, color: blue] {
+  id integer [pk, increment]
+  tenant_id integer
+  name varchar(100)
+  days_per_year integer
+  is_paid boolean
+}
+
+leave_requests [icon: calendar, color: blue] {
+  id integer [pk, increment]
+  employee_id integer
+  leave_type_id integer
+  start_date date
+  end_date date
+  status varchar(20)
+  approved_by integer
+  reason text
+}
+
+// Relationships 
+
+// Tenant Scoping
+users.company_id > tenants.id
+branches.tenant_id > tenants.id
+departments.tenant_id > tenants.id
+designations.tenant_id > tenants.id
+employees.tenant_id > tenants.id
+pay_periods.tenant_id > tenants.id
+leave_types.tenant_id > tenants.id
+
+// System Identity Link (1-to-1)
+employees.user_id - users.id 
+
+// Organizational Links
+employees.branch_id > branches.id
+employees.department_id > departments.id
+employees.designation_id > designations.id
+
+// Hierarchical Links
+employees.manager_id > employees.id [note: "Reporting Line"]
+departments.head_employee_id > employees.id [note: "Department Head"]
+
+employee_job_history.employee_id > employees.id
+
+employee_documents.employee_id > employees.id
+
+time_events.employee_id > employees.id
+
+timesheets.employee_id > employees.id
+timesheets.pay_period_id > pay_periods.id
+
+timesheet_days.timesheet_id > timesheets.id
+
+timesheet_adjustments.timesheet_day_id > timesheet_days.id
+timesheet_anomalies.timesheet_day_id > timesheet_days.id
+
+employee_compensation.employee_id > employees.id
+
+deductions.employee_id > employees.id
+
+payslips.employee_id > employees.id
+payslips.pay_period_id > pay_periods.id
+
+payslip_items.payslip_id > payslips.id
+
+leave_requests.employee_id > employees.id
+leave_requests.leave_type_id > leave_types.id
+```

--- a/docs/Entity Relationship Diagram/README.md
+++ b/docs/Entity Relationship Diagram/README.md
@@ -1,0 +1,10 @@
+# Entity Relationship Diagrams (ERD)
+
+This directory contains the database structures and relationships for the various modules of the Orchestra ERP system, documented in standard DBML format.
+
+## Available ERDs:
+
+1. **[Core System & RBAC](./SYSTEM-RBAC-ERD.md)**: The foundational identity, multi-tenancy, and security layers.
+2. **[HRIS Module](./HRIS-ERD.md)**: The human resources information system including organizations, employees, time tracking, leaves, and payroll.
+
+*Tools like [dbdiagram.io](https://dbdiagram.io) can be used to copy-paste and visualize the DBML blocks contained in these files.*

--- a/docs/Entity Relationship Diagram/SYSTEM-RBAC-ERD.md
+++ b/docs/Entity Relationship Diagram/SYSTEM-RBAC-ERD.md
@@ -1,6 +1,8 @@
-# ERD System (Enterprise Grade)
+# ERD: Core System & RBAC
 
-This diagram represents the core system and RBAC (Role-Based Access Control) architecture.
+This document outlines the core system architecture, focusing on multi-tenancy (`tenants`/`companies`) and Role-Based Access Control (`users`, `roles`, `permissions`, `menus`).
+
+## 1. Database Schema (DBML)
 
 ```dbml
 title ERD System (Enterprise Grade)
@@ -108,4 +110,40 @@ role_permissions.permission_id > permissions.id
 
 menus.parent_id - menus.id
 menus.permission_id > permissions.id
+```
+
+## 2. RBAC Table Graph Overview
+
+This table graph shows **each RBAC table**, its **role in the system**, and **how it connects to others** — useful for **documentation, audits, and onboarding**.
+
+| Table Name | Category | What It Does | Connected To |
+|----------|--------|-------------|-------------|
+| **users** | Identity | Stores all system users and login-related data | user_roles, user_permissions, rbac_audit_logs |
+| **roles** | Authorization | Defines job-based access bundles | user_roles, role_permissions |
+| **permissions** | Authorization | Defines all allowed actions in the system | role_permissions, user_permissions, menu_permissions |
+| **menus** | UI / Navigation | Defines system menus and navigation structure | menu_permissions, menus (self-reference) |
+| **menu_permissions** | UI Security | Controls which permissions are required to see a menu | menus, permissions |
+| **role_permissions** | Authorization Mapping | Assigns permissions to roles | roles, permissions |
+| **user_roles** | Authorization Mapping | Assigns roles to users per tenant | users, roles |
+| **user_permissions** | Authorization Override | Grants direct permissions to a user (exception-based) | users, permissions |
+| **rbac_audit_logs** | Security / Compliance | Logs all RBAC-related changes for auditing | users |
+
+## 3. Relationship Graph (Logical Flow)
+
+```text
+users
+ ├── user_roles
+ │    └── roles
+ │         └── role_permissions
+ │              └── permissions
+ │
+ ├── user_permissions
+ │    └── permissions
+ │
+ └── rbac_audit_logs
+
+permissions
+ └── menu_permissions
+      └── menus
+           └── menus (parent-child hierarchy)
 ```

--- a/docs/PROJECT-ROADMAP.md
+++ b/docs/PROJECT-ROADMAP.md
@@ -1,0 +1,107 @@
+# 🚀 Orchestra ERP: Master Project Plan
+
+This document serves as the high-level roadmap for the Orchestra ERP system, detailing the completed foundations and the planned business modules (Epics).
+
+---
+
+## 🏗️ Phase 1: System Foundation & Security
+*The core plumbing of the application. Everything built here is required for the business modules to function securely.*
+
+### ✅ EPIC-01: Backend RBAC & Advanced Session Management
+- **Status**: Completed
+- **Focus**: Identity, Authorization, and JWT Security.
+- **Key Features**:
+  - `User`, `Role`, and `Permission` entities.
+  - Slug-based endpoints protection (`@RequirePermissions`).
+  - Strict Tenant-Scoped data isolation.
+  - Active Session tracking and remote revocation (Hard/Soft session destruction).
+
+### ✅ EPIC-02: Frontend RBAC & Portal Layout
+- **Status**: Completed
+- **Focus**: UX, Navigation Gating, and Admin Dashboards.
+- **Key Features**:
+  - `EntityManager` and `DataTable` standardized UI patterns.
+  - Dynamic, permission-gated Sidebar navigation.
+  - Centralized Admin dashboards for Users, Roles, and Active Sessions.
+  - Smart redirection (Login loop prevention, Unauthorized boundaries).
+
+---
+
+## 🏗️ Phase 2: HR & Operations Core
+Build the foundational operational modules that drive daily business logic.
+
+- [ ] **EPIC-03: HRIS Core & Employee Management**
+  - Departments, Designations, Branches
+  - Employee Master Profile
+- [ ] **EPIC-04: HRIS Attendance & Payroll**
+  - Time Tracking & Timesheet Aggregation
+  - Leave Management Workflows
+  - Compensation, Deductions & Payslips
+- [ ] **EPIC-05: Operations Master Data**
+  - Material Master (Items, Stock levels)
+  - Bill of Materials (BOM / Recipes)
+
+---
+
+## 📦 Phase 3: Operational Modules
+*The modules that drive the actual day-to-day business tracking and supply chain.*
+
+### 📋 EPIC-04: Inventory & Asset Management
+- **Status**: Backlog
+- **Focus**: Tracking physical items, goods, and company assets.
+- **Key Features**:
+  - `Item` master list (consumables, raw materials, fixed assets).
+  - Multi-warehouse/branch stock tracking.
+  - Asset Flow: Assigning laptops/vehicles to `Employees` (depends on EPIC-03).
+  - Goods Receipt and Issuance workflows.
+
+### 📋 EPIC-05: Operations & Procurement
+- **Status**: Backlog
+- **Focus**: Supply chain requests and vendor management.
+- **Key Features**:
+  - Purchase Requisitions (PR) workflow.
+  - Vendor / Supplier master list.
+  - Purchase Orders (PO) linked to Inventory receiving.
+  - Approval Matrix (e.g., Department Heads approving PRs - depends on EPIC-03 hierarchy).
+
+---
+
+## 💰 Phase 4: Financial Operations
+*The modules that track the flow of money, highly dependent on the operational modules.*
+
+### 📋 EPIC-06: Timekeeping & Payroll
+- **Status**: Backlog
+- **Focus**: Compensating the workforce.
+- **Key Features**:
+  - Attendance tracking and Leave Management (depends on EPIC-03).
+  - Dynamic payroll generation based on designations and attendance.
+  - Payslip generation and portal viewing.
+
+### 📋 EPIC-07: Finance & Accounting (Core)
+- **Status**: Backlog
+- **Focus**: Bookkeeping and financial health tracking.
+- **Key Features**:
+  - Chart of Accounts.
+  - Accounts Payable (linked to EPIC-05 Procurement).
+  - General Ledger and Journal Entries.
+  - Basic Financial Reporting (P&L, Balance Sheet).
+
+---
+
+## 📈 Phase 5: Advanced Features & Analytics
+*Future-proofing and scaling the ERP.*
+
+### 📋 EPIC-08: Executive Dashboards & BI
+- **Status**: Backlog
+- **Focus**: Data visualization for C-suite and Management.
+- **Key Features**:
+  - Real-time widgets (Cash flow, Inventory valuation, Headcount).
+  - Exportable custom reports (PDF/Excel).
+
+### 📋 EPIC-09: Notifications & Workflow Automation
+- **Status**: Backlog
+- **Focus**: Proactive alerting and system intelligence.
+- **Key Features**:
+  - In-app notification center.
+  - Email alerts for pending approvals (Leave requests, PRs).
+  - Automated escalation rules.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,40 +1,10 @@
-# 📊 RBAC TABLE GRAPH (MARKDOWN)
+# Orchestra ERP Documentation
 
-This table graph shows **each RBAC table**, its **role in the system**, and **how it connects to others** — useful for **documentation, audits, and onboarding**.
+Welcome to the documentation suite for the Orchestra ERP system.
 
----
+## 📖 Navigation
 
-## 🧩 RBAC TABLE OVERVIEW
-
-| Table Name | Category | What It Does | Connected To |
-|----------|--------|-------------|-------------|
-| **users** | Identity | Stores all system users and login-related data | user_roles, user_permissions, rbac_audit_logs |
-| **roles** | Authorization | Defines job-based access bundles | user_roles, role_permissions |
-| **permissions** | Authorization | Defines all allowed actions in the system | role_permissions, user_permissions, menu_permissions |
-| **menus** | UI / Navigation | Defines system menus and navigation structure | menu_permissions, menus (self-reference) |
-| **menu_permissions** | UI Security | Controls which permissions are required to see a menu | menus, permissions |
-| **role_permissions** | Authorization Mapping | Assigns permissions to roles | roles, permissions |
-| **user_roles** | Authorization Mapping | Assigns roles to users per tenant | users, roles |
-| **user_permissions** | Authorization Override | Grants direct permissions to a user (exception-based) | users, permissions |
-| **rbac_audit_logs** | Security / Compliance | Logs all RBAC-related changes for auditing | users |
-
----
-
-## 🔗 RELATIONSHIP GRAPH (LOGICAL FLOW)
-
-```text
-users
- ├── user_roles
- │    └── roles
- │         └── role_permissions
- │              └── permissions
- │
- ├── user_permissions
- │    └── permissions
- │
- └── rbac_audit_logs
-
-permissions
- └── menu_permissions
-      └── menus
-           └── menus (parent-child hierarchy)
+- **[Project Roadmap](./PROJECT-ROADMAP.md)**: The high-level master plan, phases, and status of major business epics.
+- **[Entity Mapping](./ENTITY-MAPPING.md)**: Comprehensive mapping of functional business processes to technical NestJS entities and PostgreSQL tables.
+- **[Entity Relationship Diagrams (ERDs)](./Entity%20Relationship%20Diagram/README.md)**: The database schemas and relationships for core modules (RBAC, HRIS, etc.).
+- **[Epics](./epics/)**: Detailed, itemized feature plans and acceptance criteria per business domain.

--- a/docs/epics/EPIC-03-HRIS-Implementation-Plan.md
+++ b/docs/epics/EPIC-03-HRIS-Implementation-Plan.md
@@ -1,0 +1,136 @@
+# EPIC-03: HRIS Core & Employee Management
+
+| Field | Value |
+|-------|-------|
+| **Epic ID** | EPIC-03 |
+| **Epic Name** | HRIS Core & Employee Management |
+| **Status** | 📋 Planned |
+| **Priority** | High |
+| **Dependencies** | EPIC-01, EPIC-02 (RBAC & System Config) |
+
+---
+
+## 🎯 Purpose
+Establish the foundational Human Resources Information System (HRIS). This epic provides the core organizational structure (Departments, Designations, Branches) and the central `Employee` entity. By separating this from Attendance and Payroll (EPIC-04), we ensure the master data and access control foundation is solid before handling time-series and financial calculations.
+
+---
+
+## 🏗️ Architecture & Entities
+
+### Core Entities
+1. **Department**: Logical groupings within the company (e.g., IT, Finance, HR).
+2. **Designation**: Job titles and ranks (e.g., Software Engineer, Manager).
+3. **Branch**: Physical or logical locations of the company operations.
+4. **Employee**: The central business profile of a staff member. Forms a 1-to-1 relationship with the `User` entity (which handles authentication) but contains HR-specific data.
+
+---
+
+## 📝 Stories & Implementation Plan
+
+### 📌 PHASE 1: Organizational Structure (Backend)
+
+| Story ID | STORY-HR-001 |
+|----------|--------------|
+| **Name** | Organizational Master Data CRUD |
+| **Type** | Backend |
+
+**Description:**
+Create the database entities, seeders, and REST API endpoints for organizational configuration.
+
+**Tasks:**
+- [ ] Create `Department`, `Designation`, and `Branch` entities.
+- [ ] Add `tenant_id` to all entities for multi-tenant isolation.
+- [ ] Implement `CRUD` services and controllers for each entity.
+- [ ] Protect all endpoints using `PermissionsGuard` (e.g., `hris.department.manage`).
+- [ ] Update `permissions.seeder.ts` with new HRIS permission slugs.
+
+---
+
+### 📌 PHASE 2: Organizational Structure (Frontend)
+
+| Story ID | STORY-HR-002 |
+|----------|--------------|
+| **Name** | Organizational Management UI |
+| **Type** | Frontend |
+
+**Description:**
+Build the UI interfaces for HR administrators to configure the company structure. Let's utilize the established `EntityManager` pattern.
+
+**Tasks:**
+- [ ] Add "HR Settings" or "Organization" group to `sidebar.config.ts`.
+- [ ] Create RTK Query APIs: `departmentsApi.ts`, `designationsApi.ts`, `branchesApi.ts`.
+- [ ] Create UI management pages using `EntityManager`:
+  - `app/hris/departments/page.tsx`
+  - `app/hris/designations/page.tsx`
+  - `app/hris/branches/page.tsx`
+- [ ] Protect routes using `<PermissionGuard>`.
+
+---
+
+### 📌 PHASE 3: Employee Master Data (Backend)
+
+| Story ID | STORY-HR-003 |
+|----------|--------------|
+| **Name** | Employee Entity & Relationships |
+| **Type** | Backend |
+
+**Description:**
+Implement the core `Employee` profile that links a user account to their HR data, department, and designation.
+
+**Tasks:**
+- [ ] Create `Employee` entity with relationships:
+  - `user_id` -> `SystemUser` (1-to-1)
+  - `department_id` -> `Department`
+  - `designation_id` -> `Designation`
+  - `branch_id` -> `Branch`
+  - `manager_id` -> `Employee` (Self-referential for reporting hierarchy)
+- [ ] Add core HR fields: `hire_date`, `employee_code`, `status`, `emergency_contact`, etc.
+- [ ] Implement `EmployeeService` with CRUD operations, ensuring tenant isolation.
+- [ ] Ensure that creating an Employee optionally creates the system `User` account simultaneously.
+
+---
+
+### 📌 PHASE 4: Employee Management (Frontend)
+
+| Story ID | STORY-HR-004 |
+|----------|--------------|
+| **Name** | Employee Directory & Profiles |
+| **Type** | Frontend |
+
+**Description:**
+Provide a comprehensive interface for HR to manage staff members and view the company directory.
+
+**Tasks:**
+- [ ] Create `employeeApi.ts` in RTK Query.
+- [ ] Create the **Employee Directory** table view (`app/hris/employees/page.tsx`).
+- [ ] Create the **Add/Edit Employee Form**:
+  - Personal Information section.
+  - Job Information section (Dropdowns for Department, Designation, Manager).
+  - System Access section (Toggle to auto-create user account and assign roles).
+- [ ] Create **Employee Profile View**: A detailed page showing the employee's full file.
+
+---
+
+## 🔒 Security & RBAC Requirements
+
+To implement this Epic, the following new permission slugs must be defined and seeded in the database:
+
+**HRIS Read Permissions:**
+- `hris.department.view`
+- `hris.designation.view`
+- `hris.branch.view`
+- `hris.employee.view`
+
+**HRIS Write/Manage Permissions:**
+- `hris.department.manage`
+- `hris.designation.manage`
+- `hris.branch.manage`
+- `hris.employee.manage`
+
+---
+
+## ✅ Definition of Done
+1. Backend entities are fully migrated and synced to the database.
+2. All endpoints require explicit permissions via `@RequirePermissions()`.
+3. HR Administrators can create Departments, Designations, and Branches from the Portal UI.
+4. HR Administrators can onboard a new Employee, link them to an Organizational setup, and automatically provision their portal login (`User` entity).

--- a/docs/epics/EPIC-04-HRIS-Payroll-Attendance.md
+++ b/docs/epics/EPIC-04-HRIS-Payroll-Attendance.md
@@ -1,0 +1,131 @@
+# EPIC-04: HRIS Attendance, Leave & Payroll
+
+| Field | Value |
+|-------|-------|
+| **Epic ID** | EPIC-04 |
+| **Epic Name** | HRIS Attendance, Leave & Payroll |
+| **Status** | 📋 Planned |
+| **Priority** | High |
+| **Dependencies** | EPIC-01, EPIC-02, EPIC-03 (HRIS Core) |
+
+---
+
+## 🎯 Purpose
+To provide comprehensive time tracking, leave management, and automated payroll processing for the HRIS module. This epic builds upon the `Employee` master data established in EPIC-03, introducing time-series data generation, manager approvals, and financial calculations for payslips.
+
+---
+
+## 🏗️ Architecture & Entities
+
+### Core Entities
+1. **Attendance (Time Events)**: Raw clock-in/out logs capturing when and where an employee worked.
+2. **Leave Management**: Configuration of leave types (Vacation, Sick) and the employee requests for time off.
+3. **Timesheets**: Aggregations of daily `TimeEvents` into pay periods, resolving regular vs. overtime hours, handling adjustments and system anomalies.
+4. **Compensation & Deductions**: Base rates for employees and recurring/variable deductions.
+5. **Payslips**: The final calculated financial document representing an employee's earnings and deductions for a closed pay period.
+
+---
+
+## 📝 Stories & Implementation Plan
+
+### 📌 PHASE 1: Attendance & Leave System
+
+| Story ID | STORY-HR-005 |
+|----------|--------------|
+| **Name** | Time Tracking & Leave Core |
+| **Type** | Full Stack |
+
+**Description:**
+Implement the backend entities and frontend portal for employees to log time and request leaves, and for HR to configure them.
+
+**Tasks:**
+- [ ] Create `TimeEvent`, `LeaveType`, and `LeaveRequest` entities.
+- [ ] Develop API endpoints for employees to clock in/out (recording timestamp, IP, device).
+- [ ] Build the **Time Clock** UI component for the employee dashboard.
+- [ ] Implement robust leave balance calculation and approval workflows for Managers.
+- [ ] Create UI management pages for HR to define `LeaveTypes` and review `LeaveRequests`.
+
+---
+
+### 📌 PHASE 2: Timesheet Aggregation & Approvals
+
+| Story ID | STORY-HR-006 |
+|----------|--------------|
+| **Name** | Pay Periods & Timesheet Processing |
+| **Type** | Full Stack |
+
+**Description:**
+Build the engine that converts raw attendance data and approved leaves into structured, daily timesheets ready for payroll.
+
+**Tasks:**
+- [ ] Create `PayPeriod`, `Timesheet`, `TimesheetDay`, `TimesheetAdjustment`, and `TimesheetAnomaly` entities.
+- [ ] Develop a chron/service worker to automatically generate `Timesheets` at the end of a `PayPeriod`.
+- [ ] Implement logic to automatically flag anomalies (e.g., missing clock-out).
+- [ ] Build the **Timesheet Review UI** for managers to view, adjust, and approve employee timesheets.
+- [ ] Enforce strict state machine constraints (Draft -> Pending Review -> Approved -> Locked).
+
+---
+
+### 📌 PHASE 3: Compensation & Deductions Management
+
+| Story ID | STORY-HR-007 |
+|----------|--------------|
+| **Name** | Salary & Deduction Configuration |
+| **Type** | Backend/Frontend |
+
+**Description:**
+Set up the financial baseline for employees required to calculate net pay.
+
+**Tasks:**
+- [ ] Create `EmployeeCompensation` and `Deduction` entities.
+- [ ] Add the "Compensation" tab to the Employee Profile UI (from EPIC-03).
+- [ ] Implement history tracking for rate changes (effective dates).
+- [ ] Build APIs for HR to assign recurring deductions (e.g., health insurance, loan repayments).
+
+---
+
+### 📌 PHASE 4: Payroll Processing Layer
+
+| Story ID | STORY-HR-008 |
+|----------|--------------|
+| **Name** | Payslip Generation Engine |
+| **Type** | Full Stack |
+
+**Description:**
+The culmination of the HR module: taking approved timesheets and employee compensation to generate final payslips.
+
+**Tasks:**
+- [ ] Create `Payslip` and `PayslipItem` entities.
+- [ ] Develop the **Payroll Run** service that calculates Gross Pay, subtracts Deductions, and yields Net Pay.
+- [ ] Implement the **Payroll Dashboard UI** for HR to preview, confirm, and publish payslips.
+- [ ] Build the **Employee Payslip Portal** for staff to view and download PDF versions of their earnings.
+
+---
+
+## 🔒 Security & RBAC Requirements
+
+These permissions expand on the HRIS role capabilities:
+
+**Time & Leave:**
+- `hris.attendance.log` (Employee self-serve)
+- `hris.leave.request` (Employee self-serve)
+- `hris.leave.manage` (Manager/HR approval)
+
+**Timesheets:**
+- `hris.timesheet.view`
+- `hris.timesheet.manage` (Manager adjustments/approvals)
+
+**Payroll (Highly Restricted):**
+- `hris.compensation.view`
+- `hris.compensation.manage`
+- `hris.payroll.run`
+- `hris.payslip.view_own` (Employee self-serve)
+
+---
+
+## ✅ Definition of Done
+1. Employees can clock in/out and request leaves from their portal.
+2. The system correctly aggregates time events into daily and period-level timesheets.
+3. Managers can approve timesheets and leave requests.
+4. HR can define pay periods and run a full payroll cycle yielding correct payslips.
+5. All calculations properly track the tenant scope and respect the strict RBAC permission layers.


### PR DESCRIPTION
## 🔍 Overview
Reorganized the documentation structure and split the HRIS epic into two focused epics. This improves clarity, aligns the ERDs with the new naming conventions, and updates the project roadmap accordingly.

## 🚀 Key Changes
- **Documentation Structure**
  - Created `docs/Entity Relationship Diagram/` folder.
  - Added `HRIS-ERD.md` (full HRIS DBML) and `SYSTEM-RBAC-ERD.md` (RBAC core ERD).
  - Added an index `README.md` in the new folder.
  - Updated root `README.md` to serve as a master index.
- **ERD Standardization**
  - Dropped all `hr_` prefixes.
  - Replaced `company_id` with `tenant_id` across all schemas.
- **Roadmap Update**
  - Reflected the split of HRIS into EPIC‑03 (Core & Employee) and EPIC‑04 (Attendance & Payroll).
  - Adjusted subsequent epic numbers to keep the sequence consistent.
- **Cleanup**
  - Removed the outdated `ENTITY-MAPPING.md` from the root docs folder.

## 🔗 Related Issues/Epics
- Relates to EPIC‑03 (HRIS Core & Employee Management)
- Relates to EPIC‑04 (HRIS Attendance & Payroll)

## 🧪 Testing Performed
- Verified that all markdown files render correctly in the repository.
- Checked DBML syntax with a DBML viewer to ensure no broken references.
- Ran `git diff` to confirm only documentation files were affected.

## 📸 Screenshots / Recordings
*(Add any screenshots of the updated ERDs if desired)*

## 🚩 Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self‑review of my own code
- [x] I have commented my code, particularly in hard‑to‑understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
