### PR TITLE
Add HRIS payroll API endpoints and fix payslip FK

### DIFF
--- a/api.orchestra.com/src/database/migrations/1774000000000-CreatePayslips.ts
+++ b/api.orchestra.com/src/database/migrations/1774000000000-CreatePayslips.ts
@@ -1,0 +1,181 @@
+import {
+  MigrationInterface,
+  QueryRunner,
+  Table,
+  TableForeignKey,
+  TableIndex,
+} from 'typeorm';
+
+export class CreatePayslips1774000000000 implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.createTable(
+      new Table({
+        name: 'hris.payslips',
+        columns: [
+          {
+            name: 'id',
+            type: 'int',
+            isPrimary: true,
+            isGenerated: true,
+            generationStrategy: 'increment',
+          },
+          {
+            name: 'pay_period_id',
+            type: 'int',
+            isNullable: false,
+          },
+          {
+            name: 'employee_id',
+            type: 'int',
+            isNullable: false,
+          },
+          {
+            name: 'tenant_id',
+            type: 'int',
+            isNullable: false,
+          },
+          {
+            name: 'status',
+            type: 'enum',
+            enum: ['DRAFT', 'CALCULATED', 'PUBLISHED'],
+            default: `'DRAFT'`,
+          },
+          {
+            name: 'gross_pay',
+            type: 'decimal',
+            precision: 12,
+            scale: 2,
+            default: 0,
+          },
+          {
+            name: 'total_deductions',
+            type: 'decimal',
+            precision: 12,
+            scale: 2,
+            default: 0,
+          },
+          {
+            name: 'net_pay',
+            type: 'decimal',
+            precision: 12,
+            scale: 2,
+            default: 0,
+          },
+          {
+            name: 'meta',
+            type: 'jsonb',
+            isNullable: true,
+          },
+          {
+            name: 'pdf_url',
+            type: 'varchar',
+            length: '255',
+            isNullable: true,
+          },
+          {
+            name: 'created_at',
+            type: 'timestamp',
+            default: 'CURRENT_TIMESTAMP',
+          },
+          {
+            name: 'updated_at',
+            type: 'timestamp',
+            default: 'CURRENT_TIMESTAMP',
+            onUpdate: 'CURRENT_TIMESTAMP',
+          },
+        ],
+      }),
+    );
+
+    await queryRunner.createTable(
+      new Table({
+        name: 'hris.payslip_items',
+        columns: [
+          {
+            name: 'id',
+            type: 'int',
+            isPrimary: true,
+            isGenerated: true,
+            generationStrategy: 'increment',
+          },
+          {
+            name: 'payslip_id',
+            type: 'int',
+            isNullable: false,
+          },
+          {
+            name: 'type',
+            type: 'enum',
+            enum: ['EARNING', 'DEDUCTION'],
+          },
+          {
+            name: 'code',
+            type: 'varchar',
+            length: '100',
+          },
+          {
+            name: 'label',
+            type: 'varchar',
+            length: '255',
+          },
+          {
+            name: 'amount',
+            type: 'decimal',
+            precision: 12,
+            scale: 2,
+            default: 0,
+          },
+          {
+            name: 'meta',
+            type: 'jsonb',
+            isNullable: true,
+          },
+        ],
+      }),
+    );
+
+    await queryRunner.createIndex(
+      'hris.payslips',
+      new TableIndex({
+        name: 'IDX_payslips_tenant_period_employee',
+        columnNames: ['tenant_id', 'pay_period_id', 'employee_id'],
+        isUnique: true,
+      }),
+    );
+
+    await queryRunner.createForeignKeys('hris.payslips', [
+      new TableForeignKey({
+        columnNames: ['tenant_id'],
+        referencedColumnNames: ['id'],
+        referencedTableName: 'system.tenants',
+        onDelete: 'CASCADE',
+      }),
+      new TableForeignKey({
+        columnNames: ['pay_period_id'],
+        referencedColumnNames: ['id'],
+        referencedTableName: 'hris.pay_periods',
+        onDelete: 'CASCADE',
+      }),
+      new TableForeignKey({
+        columnNames: ['employee_id'],
+        referencedColumnNames: ['id'],
+        referencedTableName: 'hris.employees',
+        onDelete: 'CASCADE',
+      }),
+    ]);
+
+    await queryRunner.createForeignKeys('hris.payslip_items', [
+      new TableForeignKey({
+        columnNames: ['payslip_id'],
+        referencedColumnNames: ['id'],
+        referencedTableName: 'hris.payslips',
+        onDelete: 'CASCADE',
+      }),
+    ]);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.dropTable('hris.payslip_items');
+    await queryRunner.dropTable('hris.payslips');
+  }
+}

--- a/api.orchestra.com/src/entities/hris/payslip-item.entity.ts
+++ b/api.orchestra.com/src/entities/hris/payslip-item.entity.ts
@@ -1,0 +1,43 @@
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  ManyToOne,
+  JoinColumn,
+} from 'typeorm';
+import { Payslip } from './payslip.entity';
+
+export enum PayslipItemType {
+  EARNING = 'EARNING',
+  DEDUCTION = 'DEDUCTION',
+}
+
+@Entity('payslip_items', { schema: 'hris' })
+export class PayslipItem {
+  @PrimaryGeneratedColumn()
+  id: number;
+
+  @Column({ name: 'payslip_id' })
+  payslipId: number;
+
+  @ManyToOne(() => Payslip, (p: Payslip): PayslipItem[] => p.items, {
+    onDelete: 'CASCADE',
+  })
+  @JoinColumn({ name: 'payslip_id' })
+  payslip: Payslip;
+
+  @Column({ type: 'enum', enum: PayslipItemType })
+  type: PayslipItemType;
+
+  @Column({ type: 'varchar', length: 100 })
+  code: string;
+
+  @Column({ type: 'varchar', length: 255 })
+  label: string;
+
+  @Column({ type: 'decimal', precision: 12, scale: 2, default: 0 })
+  amount: number;
+
+  @Column({ type: 'jsonb', nullable: true })
+  meta?: Record<string, unknown>;
+}

--- a/api.orchestra.com/src/entities/hris/payslip.entity.ts
+++ b/api.orchestra.com/src/entities/hris/payslip.entity.ts
@@ -1,0 +1,92 @@
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  ManyToOne,
+  OneToMany,
+  JoinColumn,
+  CreateDateColumn,
+  UpdateDateColumn,
+} from 'typeorm';
+import { Tenant, Employee, PayPeriod } from '@/entities';
+import { PayslipItem } from './payslip-item.entity';
+
+export enum PayslipStatus {
+  DRAFT = 'DRAFT',
+  CALCULATED = 'CALCULATED',
+  PUBLISHED = 'PUBLISHED',
+}
+
+@Entity('payslips', { schema: 'hris' })
+export class Payslip {
+  @PrimaryGeneratedColumn()
+  id: number;
+
+  @Column({ name: 'pay_period_id' })
+  payPeriodId: number;
+
+  @ManyToOne(() => PayPeriod)
+  @JoinColumn({ name: 'pay_period_id' })
+  payPeriod: PayPeriod;
+
+  @Column({ name: 'employee_id' })
+  employeeId: number;
+
+  @ManyToOne(() => Employee)
+  @JoinColumn({ name: 'employee_id' })
+  employee: Employee;
+
+  @Column({ name: 'tenant_id' })
+  tenantId: number;
+
+  @ManyToOne(() => Tenant)
+  @JoinColumn({ name: 'tenant_id' })
+  tenant: Tenant;
+
+  @Column({ type: 'enum', enum: PayslipStatus, default: PayslipStatus.DRAFT })
+  status: PayslipStatus;
+
+  @Column({
+    type: 'decimal',
+    precision: 12,
+    scale: 2,
+    name: 'gross_pay',
+    default: 0,
+  })
+  grossPay: number;
+
+  @Column({
+    type: 'decimal',
+    precision: 12,
+    scale: 2,
+    name: 'total_deductions',
+    default: 0,
+  })
+  totalDeductions: number;
+
+  @Column({
+    type: 'decimal',
+    precision: 12,
+    scale: 2,
+    name: 'net_pay',
+    default: 0,
+  })
+  netPay: number;
+
+  @Column({ type: 'jsonb', name: 'meta', nullable: true })
+  meta?: Record<string, unknown>;
+
+  @Column({ type: 'varchar', length: 255, name: 'pdf_url', nullable: true })
+  pdfUrl?: string;
+
+  @OneToMany(() => PayslipItem, (item: PayslipItem) => item.payslip, {
+    cascade: true,
+  })
+  items: PayslipItem[];
+
+  @CreateDateColumn({ name: 'created_at' })
+  createdAt: Date;
+
+  @UpdateDateColumn({ name: 'updated_at' })
+  updatedAt: Date;
+}

--- a/api.orchestra.com/src/entities/index.ts
+++ b/api.orchestra.com/src/entities/index.ts
@@ -41,3 +41,5 @@ export * from './hris/timesheet-day.entity';
 export * from './hris/employee-compensation.entity';
 export * from './hris/employee-deduction.entity';
 export * from './hris/compensation-history.entity';
+export * from './hris/payslip.entity';
+export * from './hris/payslip-item.entity';

--- a/api.orchestra.com/src/modules/hris/payroll/dto/trigger-payroll-run.dto.ts
+++ b/api.orchestra.com/src/modules/hris/payroll/dto/trigger-payroll-run.dto.ts
@@ -1,0 +1,17 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsBoolean, IsInt, IsOptional, Min } from 'class-validator';
+
+export class TriggerPayrollRunDto {
+  @ApiProperty({ description: 'Pay period to run payroll for' })
+  @IsInt()
+  @Min(1)
+  payPeriodId: number;
+
+  @ApiProperty({
+    description: 'Force re-run even if payslips exist',
+    required: false,
+  })
+  @IsOptional()
+  @IsBoolean()
+  force?: boolean;
+}

--- a/api.orchestra.com/src/modules/hris/payroll/payroll.controller.ts
+++ b/api.orchestra.com/src/modules/hris/payroll/payroll.controller.ts
@@ -1,0 +1,86 @@
+import {
+  Controller,
+  Get,
+  Post,
+  Param,
+  ParseIntPipe,
+  Query,
+  Body,
+  UseGuards,
+  Req,
+} from '@nestjs/common';
+import {
+  ApiBearerAuth,
+  ApiBody,
+  ApiOperation,
+  ApiParam,
+  ApiResponse,
+  ApiQuery,
+  ApiTags,
+} from '@nestjs/swagger';
+import { PayrollService } from './payroll.service';
+import { TriggerPayrollRunDto } from './dto/trigger-payroll-run.dto';
+import { AuthenticatedGuard } from '@/guards/authenticated.guard';
+import { PermissionsGuard } from '@/guards/permissions.guard';
+import { RequirePermissions } from '@/decorators/require-permissions.decorator';
+import { Payslip } from '@/entities';
+import { AuthenticatedRequest } from '@/types/authenticated-request';
+import { RunResult } from './payroll.service';
+
+@ApiTags('HRIS - Payroll')
+@ApiBearerAuth()
+@UseGuards(AuthenticatedGuard, PermissionsGuard)
+@Controller('hris/payroll')
+export class PayrollController {
+  constructor(private readonly payrollService: PayrollService) {}
+
+  @Get('payslips')
+  @RequirePermissions('hris.payroll.view')
+  @ApiOperation({ summary: 'List payslips (optionally filter by pay period)' })
+  @ApiQuery({ name: 'payPeriodId', required: false, type: Number })
+  @ApiResponse({ status: 200, description: 'List of payslips.' })
+  listPayslips(
+    @Query('payPeriodId') payPeriodId: string | undefined,
+    @Req() req: AuthenticatedRequest,
+  ): Promise<Payslip[]> {
+    const payPeriodFilter = payPeriodId ? Number(payPeriodId) : undefined;
+    return this.payrollService.list(payPeriodFilter, req.user.tenantId!);
+  }
+
+  @Get('payslips/:id')
+  @RequirePermissions('hris.payroll.view')
+  @ApiOperation({ summary: 'Get a payslip' })
+  @ApiParam({ name: 'id', type: Number })
+  @ApiResponse({ status: 200, description: 'Returns the payslip.' })
+  @ApiResponse({ status: 404, description: 'Payslip not found.' })
+  getPayslip(
+    @Param('id', ParseIntPipe) id: number,
+    @Req() req: AuthenticatedRequest,
+  ): Promise<Payslip> {
+    return this.payrollService.get(id, req.user.tenantId!);
+  }
+
+  @Post('run')
+  @RequirePermissions('hris.payroll.manage')
+  @ApiOperation({ summary: 'Trigger payroll run for a pay period' })
+  @ApiBody({ type: TriggerPayrollRunDto })
+  @ApiResponse({ status: 200, description: 'Payroll run triggered.' })
+  triggerRun(
+    @Body() dto: TriggerPayrollRunDto,
+    @Req() req: AuthenticatedRequest,
+  ): Promise<RunResult> {
+    return this.payrollService.runPayroll(dto, req.user.tenantId!);
+  }
+
+  @Post('payslips/:id/publish')
+  @RequirePermissions('hris.payroll.manage')
+  @ApiOperation({ summary: 'Publish a payslip' })
+  @ApiParam({ name: 'id', type: Number })
+  @ApiResponse({ status: 200, description: 'Payslip published.' })
+  publishPayslip(
+    @Param('id', ParseIntPipe) id: number,
+    @Req() req: AuthenticatedRequest,
+  ): Promise<Payslip> {
+    return this.payrollService.publish(id, req.user.tenantId!);
+  }
+}

--- a/api.orchestra.com/src/modules/hris/payroll/payroll.endpoints.http
+++ b/api.orchestra.com/src/modules/hris/payroll/payroll.endpoints.http
@@ -1,0 +1,27 @@
+### Login (Establish Session) to get credentials if needed,
+### or rely on browser cookies if using an extension
+POST {{API_BASE_URL}}/v1/auth/login
+Content-Type: application/json
+
+{
+    "email": "{{TEST_USERNAME}}",
+    "password": "{{TEST_USER_PASSWORD}}"
+}
+
+### List payslips
+GET {{API_BASE_URL}}/v1/hris/payroll/payslips?payPeriodId=1
+
+### Get payslip by id
+GET {{API_BASE_URL}}/v1/hris/payroll/payslips/1
+
+### Trigger payroll run
+POST {{API_BASE_URL}}/v1/hris/payroll/run
+Content-Type: application/json
+
+{
+  "payPeriodId": 1,
+  "force": false
+}
+
+### Publish payslip
+POST {{API_BASE_URL}}/v1/hris/payroll/payslips/1/publish

--- a/api.orchestra.com/src/modules/hris/payroll/payroll.module.ts
+++ b/api.orchestra.com/src/modules/hris/payroll/payroll.module.ts
@@ -1,4 +1,32 @@
 import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import {
+  Employee,
+  EmployeeCompensation,
+  EmployeeDeduction,
+  PayPeriod,
+  Payslip,
+  PayslipItem,
+  Timesheet,
+} from '@/entities';
+import { PayrollService } from './payroll.service';
+import { PayrollController } from './payroll.controller';
+import { PermissionModule } from '@/modules/system/permissions/permission.module';
 
-@Module({})
+@Module({
+  imports: [
+    TypeOrmModule.forFeature([
+      Payslip,
+      PayslipItem,
+      PayPeriod,
+      Timesheet,
+      EmployeeCompensation,
+      EmployeeDeduction,
+      Employee,
+    ]),
+    PermissionModule,
+  ],
+  controllers: [PayrollController],
+  providers: [PayrollService],
+})
 export class PayrollModule {}

--- a/api.orchestra.com/src/modules/hris/payroll/payroll.service.ts
+++ b/api.orchestra.com/src/modules/hris/payroll/payroll.service.ts
@@ -1,0 +1,259 @@
+import {
+  ConflictException,
+  Injectable,
+  NotFoundException,
+} from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Between, Repository } from 'typeorm';
+import {
+  Employee,
+  EmployeeCompensation,
+  EmployeeDeduction,
+  PayPeriod,
+  Payslip,
+  PayslipItem,
+  PayslipItemType,
+  PayslipStatus,
+  Timesheet,
+} from '@/entities';
+import { TriggerPayrollRunDto } from './dto/trigger-payroll-run.dto';
+
+export interface RunResult {
+  generated: number;
+  skipped: number;
+}
+
+@Injectable()
+export class PayrollService {
+  constructor(
+    @InjectRepository(Payslip)
+    private readonly payslipRepo: Repository<Payslip>,
+    @InjectRepository(PayslipItem)
+    private readonly payslipItemRepo: Repository<PayslipItem>,
+    @InjectRepository(PayPeriod)
+    private readonly payPeriodRepo: Repository<PayPeriod>,
+    @InjectRepository(Timesheet)
+    private readonly timesheetRepo: Repository<Timesheet>,
+    @InjectRepository(EmployeeCompensation)
+    private readonly compensationRepo: Repository<EmployeeCompensation>,
+    @InjectRepository(EmployeeDeduction)
+    private readonly deductionRepo: Repository<EmployeeDeduction>,
+    @InjectRepository(Employee)
+    private readonly employeeRepo: Repository<Employee>,
+  ) {}
+
+  async runPayroll(
+    payload: TriggerPayrollRunDto,
+    tenantId: number,
+  ): Promise<RunResult> {
+    const payPeriod = await this.payPeriodRepo.findOne({
+      where: { id: payload.payPeriodId, tenantId },
+    });
+    if (!payPeriod) {
+      throw new NotFoundException('Pay period not found');
+    }
+
+    const timesheets = await this.timesheetRepo.find({
+      where: { payPeriodId: payPeriod.id, tenantId },
+    });
+
+    let generated = 0;
+    let skipped = 0;
+
+    for (const ts of timesheets) {
+      const existing = await this.payslipRepo.findOne({
+        where: {
+          payPeriodId: payPeriod.id,
+          employeeId: ts.employeeId,
+          tenantId,
+        },
+      });
+      if (existing && !payload.force) {
+        skipped++;
+        continue;
+      }
+
+      const { gross, deductionsTotal, net, items } =
+        await this.buildPayslipAmounts(ts, payPeriod);
+
+      const payslip = this.payslipRepo.create({
+        id: existing?.id,
+        payPeriodId: payPeriod.id,
+        employeeId: ts.employeeId,
+        tenantId,
+        status: PayslipStatus.CALCULATED,
+        grossPay: gross,
+        totalDeductions: deductionsTotal,
+        netPay: net,
+        items,
+        meta: {
+          timesheetId: ts.id,
+          totalRegularHours: ts.totalRegularHours,
+          totalOvertimeHours: ts.totalOvertimeHours,
+        },
+      });
+      await this.payslipRepo.save(payslip);
+      generated++;
+    }
+
+    return { generated, skipped };
+  }
+
+  async list(
+    payPeriodId: number | undefined,
+    tenantId: number,
+  ): Promise<Payslip[]> {
+    return this.payslipRepo.find({
+      where: payPeriodId ? { payPeriodId, tenantId } : { tenantId },
+      relations: ['items'],
+      order: { id: 'DESC' },
+    });
+  }
+
+  async get(id: number, tenantId: number): Promise<Payslip> {
+    const payslip = await this.payslipRepo.findOne({
+      where: { id, tenantId },
+      relations: ['items', 'employee', 'payPeriod'],
+    });
+    if (!payslip) {
+      throw new NotFoundException('Payslip not found');
+    }
+    return payslip;
+  }
+
+  async publish(id: number, tenantId: number): Promise<Payslip> {
+    const payslip = await this.get(id, tenantId);
+    if (payslip.status === PayslipStatus.PUBLISHED) {
+      throw new ConflictException('Payslip already published');
+    }
+    payslip.status = PayslipStatus.PUBLISHED;
+    return this.payslipRepo.save(payslip);
+  }
+
+  private async buildPayslipAmounts(
+    ts: Timesheet,
+    payPeriod: PayPeriod,
+  ): Promise<{
+    gross: number;
+    deductionsTotal: number;
+    net: number;
+    items: PayslipItem[];
+  }> {
+    const compensation = await this.getActiveCompensation(
+      ts.employeeId,
+      payPeriod,
+    );
+    const deductions = await this.getActiveDeductions(ts.employeeId, payPeriod);
+
+    const hourlyRate = compensation?.hourlyRate
+      ? Number(compensation.hourlyRate)
+      : compensation?.baseSalary
+        ? Number(compensation.baseSalary) / (this.getPeriodDays(payPeriod) * 8)
+        : 0;
+    const overtimeRateMultiplier = compensation?.overtimeRate || 1.5;
+
+    const regularPay = ts.totalRegularHours * hourlyRate;
+    const overtimePay =
+      ts.totalOvertimeHours * hourlyRate * overtimeRateMultiplier;
+    const gross = this.roundCurrency(regularPay + overtimePay);
+
+    const deductionItems = deductions.map((d) => {
+      const amount = this.calculateDeductionAmount(d, gross);
+      return this.payslipItemRepo.create({
+        type: PayslipItemType.DEDUCTION,
+        code: d.name,
+        label: d.name,
+        amount: this.roundCurrency(amount),
+        meta: { deductionId: d.id, type: d.type },
+      });
+    });
+
+    const earningsItems: PayslipItem[] = [
+      this.payslipItemRepo.create({
+        type: PayslipItemType.EARNING,
+        code: 'REGULAR',
+        label: 'Regular Pay',
+        amount: this.roundCurrency(regularPay),
+        meta: { hours: ts.totalRegularHours },
+      }),
+      this.payslipItemRepo.create({
+        type: PayslipItemType.EARNING,
+        code: 'OVERTIME',
+        label: 'Overtime Pay',
+        amount: this.roundCurrency(overtimePay),
+        meta: {
+          hours: ts.totalOvertimeHours,
+          rateMultiplier: overtimeRateMultiplier,
+        },
+      }),
+    ];
+
+    const deductionsTotal = this.roundCurrency(
+      deductionItems.reduce((sum, item) => sum + Number(item.amount), 0),
+    );
+    const net = this.roundCurrency(gross - deductionsTotal);
+
+    return {
+      gross,
+      deductionsTotal,
+      net,
+      items: [...earningsItems, ...deductionItems],
+    };
+  }
+
+  private async getActiveCompensation(
+    employeeId: number,
+    payPeriod: PayPeriod,
+  ): Promise<EmployeeCompensation | null> {
+    const start = new Date(payPeriod.startDate);
+    const end = new Date(new Date(payPeriod.endDate).setHours(23, 59, 59));
+    return this.compensationRepo.findOne({
+      where: {
+        employeeId,
+        effectiveDate: Between(start, end),
+        isActive: true,
+      },
+      order: { effectiveDate: 'DESC' },
+    });
+  }
+
+  private async getActiveDeductions(
+    employeeId: number,
+    payPeriod: PayPeriod,
+  ): Promise<EmployeeDeduction[]> {
+    const start = new Date(payPeriod.startDate);
+    const end = new Date(new Date(payPeriod.endDate).setHours(23, 59, 59));
+    return this.deductionRepo.find({
+      where: {
+        employeeId,
+        effectiveDate: Between(start, end),
+        isActive: true,
+      },
+    });
+  }
+
+  private calculateDeductionAmount(
+    d: EmployeeDeduction,
+    gross: number,
+  ): number {
+    if (d.type === 'percentage' && d.percentage) {
+      return (gross * Number(d.percentage)) / 100;
+    }
+    if (d.amount) return Number(d.amount);
+    return 0;
+  }
+
+  private getPeriodDays(period: PayPeriod): number {
+    const start = new Date(period.startDate).getTime();
+    const end = new Date(period.endDate).getTime();
+    const diffDays = Math.max(
+      1,
+      Math.round((end - start) / (1000 * 60 * 60 * 24) + 1),
+    );
+    return diffDays;
+  }
+
+  private roundCurrency(value: number): number {
+    return Math.round((value + Number.EPSILON) * 100) / 100;
+  }
+}

--- a/docs/epics/EPIC-03-HRIS-Implementation-Plan.md
+++ b/docs/epics/EPIC-03-HRIS-Implementation-Plan.md
@@ -108,6 +108,8 @@ Provide a comprehensive interface for HR to manage staff members and view the co
   - Job Information section (Dropdowns for Department, Designation, Manager).
   - System Access section (Toggle to auto-create user account and assign roles).
 - [x] Create **Employee Profile View**: A detailed page showing the employee's full file.
+- [x] Add **Employee Onboarding Wizard** at `/hris/employees/onboarding` with steps for Personal Info, Job Details, Work Schedule, Compensation, Deductions, and Review; includes sidebar progress and summary components.
+- [x] Inline Compensation & Deductions editing inside the employee table expansion; "Add Employee" now routes to onboarding wizard.
 
 ---
 

--- a/docs/frontend/entity-manager-standard.md
+++ b/docs/frontend/entity-manager-standard.md
@@ -162,6 +162,20 @@ export default function EntityPage() {
 }
 ```
 
+### 3.1 Page composition must be hook-driven (no heavy logic in page)
+
+- Move data fetching, mutations, validation, and inline-edit handlers into a dedicated hook (e.g., `useEmployee`).
+- The page should **only** compose UI (buttons, headers, EntityManager) and read handlers/state from the hook.
+- For inline expandable rows, have the hook return a `renderExpandedRow` factory (can use `React.createElement`) so the page stays JSX-light.
+- Build dynamic form options inside the hook and return a ready `formFields` array; keep `form-fields.ts` static for structure only.
+- Keep columns in `column.tsx` pure (no business logic); pass any extra props via the page/hook pattern.
+
+### 3.2 Creation flows and onboarding
+
+- For simple CRUD, wire `onCreate` to the hook handlers.
+- For complex onboarding (multi-step wizard), **do not** open the EntityManager form; instead, surface a CTA that redirects to the onboarding route (e.g., `router.push("/hris/employees/onboarding")`).
+- Remove redundant table action columns when the expanded row already provides edit controls.
+
 ## Key Benefits
 
 1.  **Consistency**: All CRUD pages look and behave the same.

--- a/portal.orchestra.com/hooks/hris/useEmployee.ts
+++ b/portal.orchestra.com/hooks/hris/useEmployee.ts
@@ -386,7 +386,7 @@ export function useEmployee() {
   const dirtyEmployeeIds = inlineEdits.getDirtyEmployeeIds();
 
   // Redirect to onboarding flow
-  const handleAddEmployee = () => router.push("/employee/onboarding");
+  const handleAddEmployee = () => router.push("/hris/employees/onboarding");
 
   return {
     data,


### PR DESCRIPTION
## 🔍 Overview
Add HRIS payroll API endpoints (list/get payslips, run payroll, publish) and fix payslips migration FK schema to system tenants. Include HTTP examples and permission module wiring.

## 🚀 Key Changes
- **HRIS Payroll Module**: Wire TypeORM repositories, add controller with run/list/get/publish endpoints, export RunResult typing.
- **Migrations**: Fix payslips FK to reference `system.tenants`.
- **Docs/HTTP**: Add/adjust payroll `.endpoints.http` with v1 paths and login helper.

## 🔗 Related Issues/Epics
- Fixes #
- Relates to EPIC-

## 🧪 Testing Performed
- [ ] Automated tests passed
- [x] Manual verification completed (POST /api/v1/hris/payroll/run, list/get/publish payslips)
- [ ] UI/UX checked across multiple screen sizes

## 📸 Screenshots / Recordings
<!-- If applicable -->

## 🚩 Checklist
- [ ] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (HTTP examples)
- [x] My changes generate no new warnings