### PR TITLE
chore(docs): update roadmap and tech debt tracking for HRIS pause

### DIFF
--- a/docs/PROJECT-ROADMAP.md
+++ b/docs/PROJECT-ROADMAP.md
@@ -26,14 +26,17 @@ This document serves as the high-level roadmap for the Orchestra ERP system, det
 ## 🏗️ Phase 2: HR & Operations Core
 Build the foundational operational modules that drive daily business logic.
 
-- [ ] **EPIC-02: HRIS Core & Employee Management**
+- ✅ **EPIC-02: HRIS Core & Employee Management** (delivered)
   - Departments, Designations, Branches
   - Employee Master Profile
-- [ ] **EPIC-03: HRIS Attendance & Payroll**
+- ✅ **EPIC-03: HRIS Attendance & Payroll** (delivered; see EPIC-04 HRIS doc for payroll/attendance)
   - Time Tracking & Timesheet Aggregation
   - Leave Management Workflows
   - Compensation, Deductions & Payslips
-- [ ] **EPIC-04: Operations Master Data**
+- 🚧 **EPIC-05: HRIS API Completion** (partially delivered; parked)
+  - Done: import/export entities, migrations, permissions, endpoints scaffold
+  - Pending (parked): reporting/analytics, import/export workers & FilesService, notifications/webhooks, audit trail, API v2/docs (see tech-debt)
+- 📋 **EPIC-04: Operations Master Data** (next candidate)
   - Material Master (Items, Stock levels)
   - Bill of Materials (BOM / Recipes)
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -4,7 +4,10 @@ Welcome to the documentation suite for the Orchestra ERP system.
 
 ## 📖 Navigation
 
-- **[Project Roadmap](./PROJECT-ROADMAP.md)**: The high-level master plan, phases, and status of major business epics.
-- **[Entity Mapping](./ENTITY-MAPPING.md)**: Comprehensive mapping of functional business processes to technical NestJS entities and PostgreSQL tables.
-- **[Entity Relationship Diagrams (ERDs)](./Entity%20Relationship%20Diagram/README.md)**: The database schemas and relationships for core modules (RBAC, HRIS, etc.).
-- **[Epics](./epics/)**: Detailed, itemized feature plans and acceptance criteria per business domain.
+| Link | Purpose |
+| --- | --- |
+| [Project Roadmap](./PROJECT-ROADMAP.md) | High-level master plan, phases, and status of major business epics. |
+| [Entity Mapping](./ENTITY-MAPPING.md) | Mapping of business processes to NestJS entities and PostgreSQL tables. |
+| [Entity Relationship Diagrams (ERDs)](./Entity%20Relationship%20Diagram/README.md) | Database schemas and relationships for core modules (RBAC, HRIS, etc.). |
+| [Epics](./epics/) | Detailed feature plans and acceptance criteria per domain. |
+| [Tech Debt Tracker](./tech-debt/README.md) | Catalog of deferred items and remediation plans (HRIS backend gaps, settings UI, import/export). |

--- a/docs/epics/EPIC-05-HRIS-API-Completion.md
+++ b/docs/epics/EPIC-05-HRIS-API-Completion.md
@@ -4,7 +4,7 @@
 |-------|-------|
 | **Epic ID** | EPIC-05 |
 | **Epic Name** | HRIS API Completion & Optimization |
-| **Status** | 🚧 In Progress |
+| **Status** | 🚧 In Progress (import/export backend scaffolded; queues & files pending) |
 | **Priority** | High |
 | **Dependencies** | EPIC-01, EPIC-02, EPIC-03, EPIC-04 |
 
@@ -56,9 +56,9 @@ Finalize and polish all outstanding HRIS APIs to deliver a fully self-contained,
 | **Type** | Full Stack |
 
 **Tasks:**
-- [ ] Create `ImportJob` & `ExportJob` entities with status tracking.
+- [x] Create `ImportJob` & `ExportJob` entities with status tracking.
 - [ ] Build queue workers using BullMQ for parsing & generation.
-- [ ] Implement `/imports` and `/exports` REST endpoints with presigned S3 upload/download.
+- [ ] Implement `/imports` and `/exports` REST endpoints with presigned S3 upload/download. *(API scaffolds exist; add presigned URL + worker wiring)*
 - [ ] Develop React wizard UI components for HR admins.
 - [ ] Add Excel template generation utility.
 

--- a/docs/tech-debt/README.md
+++ b/docs/tech-debt/README.md
@@ -1,0 +1,16 @@
+# Tech Debt Backlog
+
+## Table of Contents
+
+| Item | Module/Area | Where to Apply | Description |
+| --- | --- | --- | --- |
+| [Bulk Import/Export APIs – Implementation Plan](./bulk-import-export-implementation-plan.md) | <span style="color:#fff;background:#2563eb;padding:2px 6px;border-radius:6px;">API (HRIS)</span> | Backend queues, FilesService, imports/exports endpoints | Finish BullMQ workers, presigned URLs, and job processing to make bulk import/export functional. |
+| [HRIS Settings Frontend](./hris-settings-frontend.md) | <span style="color:#fff;background:#16a34a;padding:2px 6px;border-radius:6px;">Portal (HRIS)</span> | Frontend settings page (`/settings/hris`) | Add HRIS settings UI for compensation brackets and statutory deductions (SSS/PhilHealth/Pag-IBIG, etc.). |
+| [HRIS Remaining Backend (EPIC-05)](./hris-remaining-backend.md) | <span style="color:#fff;background:#2563eb;padding:2px 6px;border-radius:6px;">API (HRIS)</span> | Reporting, import/export execution, notifications/webhooks, audit trail, API v2/docs | Deferred HRIS backend scope: reports, workers/files, notifications/webhooks, audit trail, API v2 + OpenAPI. |
+| Reporting & Analytics (HRIS) | <span style="color:#fff;background:#2563eb;padding:2px 6px;border-radius:6px;">API (HRIS)</span> | Materialized views, `/reports/{reportKey}` CSV/JSON, seed `hris.report.view`, docs | Pending while HRIS is parked; needed for insights/compliance exports. |
+| Notifications & Webhooks (HRIS) | <span style="color:#fff;background:#2563eb;padding:2px 6px;border-radius:6px;">API (HRIS)</span> | Templates/subscriptions, HR event emits, email/in-app/webhook dispatch | Pending; enables user/event alerts and integrations. |
+| Audit Trail (HRIS) | <span style="color:#fff;background:#2563eb;padding:2px 6px;border-radius:6px;">API (HRIS)</span> | Before/after capture, `/audit-log` filters, restore with `hris.audit.restore` | Pending; needed for traceability and recovery. |
+| API v2 & Docs (HRIS) | <span style="color:#fff;background:#2563eb;padding:2px 6px;border-radius:6px;">API (HRIS)</span> | `/api/v2/hris` prefix, harmonized DTOs/errors/pagination, OpenAPI 3.1 | Pending; needed for consistency and client upgrade path. |
+
+## Overview
+This directory tracks known technical debt and planned remediation work. Each item documents the gap, impact, and a concrete plan to resolve it.

--- a/docs/tech-debt/bulk-import-export-implementation-plan.md
+++ b/docs/tech-debt/bulk-import-export-implementation-plan.md
@@ -1,0 +1,53 @@
+# Bulk Import/Export APIs – Implementation Plan
+
+This plan closes the tech debt for bulk import/export by adding BullMQ workers, presigned file handling, and wiring controllers/services to queues.
+
+## Goals
+- Execute import/export jobs asynchronously with BullMQ workers.
+- Provide presigned upload/download URLs for files.
+- Surface job progress/status and errors via existing endpoints.
+
+## Scope
+- Backend only (NestJS). No UI work included here.
+- Datasets: employees, timesheets, payslips (adjust as needed).
+- Storage: S3-compatible presigned URLs (configure bucket/prefix via env).
+
+## Plan
+1) **Queues & Configuration**
+   - Add BullMQ queue registration (e.g., `IMPORT_QUEUE`, `EXPORT_QUEUE`) with Redis config from env.
+   - Define queue processors for import/export jobs; set concurrency and retries/backoff.
+   - Add a dead-letter strategy or failure handler logging.
+
+2) **FilesService (presigned URLs)**
+   - Implement a service to generate presigned PUT for uploads (imports) and GET for downloads (exports).
+   - Enforce content type/size limits; namespace keys by tenant/dataset/date.
+   - Return fileKey + URL to the caller; store fileKey on job records.
+
+3) **Import Worker**
+   - Pull job payload, download file via fileKey, parse CSV/XLSX (library choice), validate rows.
+   - Upsert domain records per dataset; record per-row errors; update progress in DB.
+   - Mark job status COMPLETED or FAILED with error details.
+
+4) **Export Worker**
+   - Query dataset rows, generate CSV/XLSX to a temp file/stream.
+   - Upload to storage; set `fileKey` and mark status COMPLETED (or FAILED on error).
+   - Support incremental progress updates.
+
+5) **Controller/Service Wiring**
+   - On create import/export request: enqueue a job (tenantId, dataset, fileKey, requestedBy, clientRequestId).
+   - Use FilesService to issue presigned URLs for upload/download as needed.
+   - Ensure status endpoints read DB state (no in-memory coupling).
+
+6) **Env & RBAC**
+   - Add Redis and storage env vars (host, port, password, bucket, region, TTLs).
+   - Confirm permissions: `hris.import.manage`, `hris.export.manage` already seeded; add worker-side guards if needed.
+
+7) **Monitoring & Observability**
+   - Log job lifecycle events; consider BullMQ metrics (counts, failures).
+   - Optionally expose a health endpoint that checks Redis connectivity.
+
+## Definition of Done
+- Import/export jobs process end-to-end via BullMQ workers without manual intervention.
+- Presigned URLs are issued and honored for uploads/downloads.
+- Job status/progress reflects reality; failures surface meaningful errors.
+- Configuration for Redis and storage is documented in env files.

--- a/docs/tech-debt/hris-remaining-backend.md
+++ b/docs/tech-debt/hris-remaining-backend.md
@@ -1,0 +1,36 @@
+# HRIS Remaining Backend (EPIC-05)
+
+Deferred scope from EPIC-05 while core HRIS features operate. These items add reporting, job execution, notifications, auditability, and API v2 hardening.
+
+## Gaps
+- Reporting & analytics: no materialized views or `/reports/{reportKey}` endpoints; `hris.report.view` permission not seeded for reporting use.
+- Bulk import/export execution: queue workers + FilesService missing; jobs remain pending without processing.
+- Notifications & webhooks: templates/subscriptions and event dispatch not implemented.
+- Audit trail: before/after capture and `/audit-log` querying not implemented.
+- API v2 & docs: no `/api/v2/hris` routing or harmonized DTO/error contracts; OpenAPI 3.1 not published.
+
+## Impact
+- Missing reporting blocks insights and compliance exports.
+- Import/export jobs cannot run, leading to user confusion and manual work.
+- No notifications/webhooks reduces UX and integration readiness.
+- No audit trail limits traceability and recovery (restore).
+- API v2/docs gap risks inconsistency and slower client adoption.
+
+## Suggested Remediation (high level)
+1) Reporting & Analytics
+   - Define materialized views; add `/reports/{reportKey}` CSV/JSON endpoints; seed `hris.report.view`; document payloads.
+2) Bulk Import/Export Execution
+   - Implement BullMQ workers, FilesService for presigned URLs, wire controllers to queues; add progress/error reporting.
+3) Notifications & Webhooks
+   - Add `NotificationTemplate`/`WebhookSubscription` entities, emit HR events (leave/timesheet/payroll), dispatch email/in-app/webhook; admin subscription endpoints.
+4) Audit Trail
+   - Middleware for before/after snapshots; `/audit-log` filters; restore with `hris.audit.restore` permission.
+5) API v2 & Documentation
+   - Introduce `/api/v2/hris` prefix; harmonize DTOs/pagination/errors; generate OpenAPI 3.1 and publish; migration guide.
+
+## Definition of Done
+- Reporting endpoints deliver CSV/JSON from defined report keys with RBAC enforced.
+- Import/export jobs run end-to-end via workers with presigned uploads/downloads and accurate status/progress.
+- Notifications/webhooks deliver events per configured subscriptions; admin UI can manage templates/subscriptions.
+- Audit trail captures before/after and supports filtered queries and restore.
+- API v2 available with documented contracts and upgrade guide.

--- a/docs/tech-debt/hris-settings-frontend.md
+++ b/docs/tech-debt/hris-settings-frontend.md
@@ -1,0 +1,51 @@
+# HRIS Settings Frontend
+
+This item tracks the missing HRIS Settings page in the portal where admins can manage compensation brackets and statutory deductions (e.g., SSS, PhilHealth, Pag-IBIG, custom deductions).
+
+## Gap
+- No HRIS settings surface in the portal for configuring compensation/deduction tables.
+- Admins cannot self-serve updates to brackets; changes require backend or data fixes.
+
+## Impact
+- Blocks payroll accuracy and compliance self-service.
+- Increases manual ops and risk of stale deduction rates.
+
+## Proposed Approach
+1) **Navigation**
+   - Add sidebar entry under Settings → HRIS Settings (portal app).
+   - Route: `/settings/hris` (SSR/client as per existing app patterns).
+
+2) **Page Layout**
+   - Sections: Compensation Brackets, Statutory Deductions (SSS/PhilHealth/Pag-IBIG), Other Deductions (custom).
+   - Use tabs or cards for each section; include data tables with CRUD and import/export buttons.
+
+3) **Data Sources**
+   - Backed by HRIS APIs (to be confirmed/created):
+     - GET/POST/PUT/DELETE compensation brackets
+     - GET/POST/PUT/DELETE deduction tables
+     - Optional bulk import/export endpoints for rate tables
+
+4) **CRUD Flows**
+   - List with pagination/search.
+   - Create/edit modal with validation (amount thresholds, effective dates).
+   - Soft delete or archive where applicable.
+
+5) **RBAC & Guardrails**
+   - Restrict to HR/Payroll admin roles; hide nav if lacking permission.
+   - Audit trail hooks where available.
+
+6) **UX Notes**
+   - Show effective date ranges and versioning (e.g., "effective from" labels).
+   - Provide inline hints for statutory rates and references.
+
+7) **Technical Tasks**
+   - Add page at `app/settings/hris/page.tsx` with layout + wiring to API hooks.
+   - Create hooks/services for HRIS settings APIs.
+   - Add forms/tables using existing UI kit (cards, tables, modals, tabs).
+   - Add loading/error states and toast feedback.
+
+## Definition of Done
+- HRIS Settings page reachable via sidebar.
+- Admins can view and manage compensation brackets and statutory deductions.
+- RBAC enforced; unauthorized users do not see or access the page.
+- Validations prevent invalid ranges; errors surfaced clearly.


### PR DESCRIPTION
## Summary
- Update project roadmap to mark HRIS core/attendance delivered, park remaining HRIS API completion, and highlight Operations Master Data as next candidate.
- Add tech-debt tracker entries for HRIS remaining backend scope, import/export execution, and HRIS settings frontend; link tracker from docs.
- Document deferred HRIS backend gaps in detail (reporting, workers/files, notifications/webhooks, audit trail, API v2/docs).

## Testing
- Not applicable (docs-only changes).