### PR TITLE
chore(docs): add module feature maps and updated breakdowns for HRIS,…

### DIFF
--- a/docs/modules/README.MD
+++ b/docs/modules/README.MD
@@ -1,0 +1,46 @@
+# ERP Modules Reference
+
+## ERP System Overview
+The Orchestra ERP platform centralizes operational, financial, and workforce data into a single, modular system. Each domain is encapsulated as its own module, enabling teams to evolve capabilities independently while sharing consistent security, workflow, and reporting patterns.
+
+## Core Modules
+| Module Name | Description | Details |
+| --- | --- | --- |
+| **HRIS** | Manages the full employee lifecycle, including onboarding, attendance, payroll, and compliance artifacts. | [Module guide](./hris/README.md) |
+| **SYSTEM** | Provides tenant provisioning, authentication, RBAC, and shared configuration services for every module. | [Module guide](./system/README.md) |
+| **OPERATIONS** | Covers manufacturing, inventory, BOMs, and fulfillment workflows to keep supply chains synchronized. | [Module guide](./operations/README.md) |
+| **FINANCE** | Handles GL integration, payables/receivables, and financial controls with audit-ready data flows. | Coming soon |
+| **REPORTS** | Aggregates cross-module metrics, KPIs, and executive dashboards for real-time insight. | Coming soon |
+| **CRM** | Tracks customer accounts, pipelines, and engagements with hand-offs into operations and finance. | Coming soon |
+
+### Module Documentation
+- [SYSTEM module breakdown](./system/README.md)
+- [HRIS module breakdown](./hris/README.md)
+- [OPERATIONS module breakdown](./operations/README.md)
+
+### Roadmap Snapshot
+- **Phase 1 – System Foundation**: RBAC, multi-tenant identity, and session security completed (see [EPIC-01-RBAC](../epics/EPIC-01-RBAC.md)).
+- **Phase 2 – HR & Operations Core**: HRIS core, attendance, and payroll epics delivered; Operations master data underway (materials, warehouses, BOMs). Refer to [PROJECT-ROADMAP](../PROJECT-ROADMAP.md) for status callouts.
+- **Upcoming Modules**: Inventory, procurement, finance, and analytics epics are queued with dependencies on Phase 2 deliverables.
+
+## Key Features
+- Role-based access control spanning every module
+- Scalable, event-driven architecture for high-volume transactions
+- Unified audit logging and compliance reporting
+- Configurable workflows and approval chains
+- Real-time reporting with export-ready datasets
+
+## Getting Started
+```bash
+# Clone the repository
+git clone https://github.com/your-org/erp-orchestra.git && cd erp-orchestra
+
+# Install dependencies (server + client)
+npm install
+
+# Run the stack (example)
+npm run dev
+```
+
+---
+For additional module-specific details, see the individual documentation under `docs/modules/`.

--- a/docs/modules/hris/FEATURES.md
+++ b/docs/modules/hris/FEATURES.md
@@ -1,0 +1,25 @@
+# HRIS Module Feature ↔ Epic Map
+
+This document connects HRIS capabilities to their governing epics so you can trace implementation status, requirements, and future scope.
+
+## Feature Coverage Table
+| Feature Area | Status | Epic / Doc | Notes |
+| --- | --- | --- | --- |
+| Organizational Master Data (Departments, Designations, Branches) | ✅ Delivered | [EPIC-03 HRIS Core & Employee Management](../../epics/EPIC-03-HRIS-Implementation-Plan.md) | Backend + frontend CRUD, tenant isolation, permission-guarded UIs. |
+| Employee Master Profiles & Onboarding | ✅ Delivered | [EPIC-03 HRIS Core & Employee Management](../../epics/EPIC-03-HRIS-Implementation-Plan.md#%F0%9F%93%8C-phase-3-employee-master-data-backend) | Employee entity with hierarchy, onboarding wizard, user provisioning toggle. |
+| Attendance & Leave Management | ✅ Delivered | [EPIC-04 HRIS Attendance, Leave & Payroll](../../epics/EPIC-04-HRIS-Payroll-Attendance.md#%F0%9F%93%8C-phase-1-attendance-leave-system) | Time clock, leave balances, approval flows, RBAC-protected endpoints. |
+| Timesheet Aggregation & Approvals | ✅ Delivered | [EPIC-04 HRIS Attendance, Leave & Payroll](../../epics/EPIC-04-HRIS-Payroll-Attendance.md#%F0%9F%93%8C-phase-2-timesheet-aggregation-approvals) | Cron-based generation, anomaly detection, manager review UI, manual triggers. |
+| Compensation & Deductions Management | ✅ Delivered | [EPIC-04 HRIS Attendance, Leave & Payroll](../../epics/EPIC-04-HRIS-Payroll-Attendance.md#%F0%9F%93%8C-phase-3-compensation-deductions-management) | Compensation tabs, standalone pages, history tracking, permission gating. |
+| Payroll Run & Payslip Portal | ✅ Delivered | [EPIC-04 HRIS Attendance, Leave & Payroll](../../epics/EPIC-04-HRIS-Payroll-Attendance.md#%F0%9F%93%8C-phase-4-payroll-processing-layer) | Payroll engine, HR dashboard, employee payslip downloads, audit logging. |
+| Reporting & Analytics APIs | 🚧 In Progress | [EPIC-05 HRIS API Completion](../../epics/EPIC-05-HRIS-API-Completion.md#%F0%9F%93%8C-phase-1-reporting-analytics-apis) | Materialized views + `/reports/{key}` endpoints underway. |
+| Bulk Import/Export (Employees, Timesheets, Payslips) | 🚧 In Progress | [EPIC-05 HRIS API Completion](../../epics/EPIC-05-HRIS-API-Completion.md#%F0%9F%93%8C-phase-2-bulk-import-export-module) | Job entities + API scaffold done; BullMQ workers + presigned URLs pending. |
+| Notifications & Webhooks for HR Events | 📋 Planned | [EPIC-05 HRIS API Completion](../../epics/EPIC-05-HRIS-API-Completion.md#%F0%9F%93%8C-phase-3-notifications-webhooks) | Domain events + dispatcher queued for next milestone. |
+| Audit Log Queries & Restore | 📋 Planned | [EPIC-05 HRIS API Completion](../../epics/EPIC-05-HRIS-API-Completion.md#%F0%9F%93%8C-phase-4-audit-trail-queries) | API + RBAC scopes scheduled with V2 rollout. |
+| HRIS API v2 & Docs | 📋 Planned | [EPIC-05 HRIS API Completion](../../epics/EPIC-05-HRIS-API-Completion.md#%F0%9F%93%8C-phase-5-api-version-2-documentation) | Versioned endpoints, OpenAPI 3.1, migration guides. |
+
+## How to Use This File
+- **Product / Delivery** – Spot what’s GA vs. in-flight and jump straight into the epic for scope.
+- **Engineering** – Align feature enhancements with the authoritative requirements document.
+- **QA / Compliance** – Map test plans and audits to the exact epic responsible for each capability.
+
+For the full HRIS narrative and roadmap references, see `docs/modules/README.md` and the individual epic files under `docs/epics/`.

--- a/docs/modules/hris/README.MD
+++ b/docs/modules/hris/README.MD
@@ -1,0 +1,21 @@
+# HRIS Module Overview
+
+## Purpose
+The HRIS module covers the entire employee lifecycle: organizational structure, employee master data, time & attendance, leave, compensation, and payroll. It builds on the SYSTEM module for identity/RBAC and feeds OPERATIONS and FINANCE with accurate workforce data.
+
+## Current Picture
+| Capability | Status | Notes |
+| --- | --- | --- |
+| Org Master Data | ✅ Delivered | Departments, designations, branches with portal CRUD. |
+| Employee Profiles & Onboarding | ✅ Delivered | Employee entity, onboarding wizard, auto-provision user access. |
+| Attendance & Leave | ✅ Delivered | Time clock, leave balances, approvals, employee self-service. |
+| Timesheets & Approvals | ✅ Delivered | Automated generation, anomaly detection, manager workflow. |
+| Compensation & Deductions | ✅ Delivered | Compensation tabs, standalone CRUD, history tracking. |
+| Payroll & Payslips | ✅ Delivered | Payroll run service, HR dashboard, employee payslip portal. |
+| Reporting / Import / Notifications | 🚧 In Progress | Covered by EPIC-05; see feature map for scope. |
+
+## References
+- [Feature ↔ Epic Map](./FEATURES.md)
+- [EPIC-03 HRIS Core & Employee Management](../../epics/EPIC-03-HRIS-Implementation-Plan.md)
+- [EPIC-04 HRIS Attendance, Leave & Payroll](../../epics/EPIC-04-HRIS-Payroll-Attendance.md)
+- [EPIC-05 HRIS API Completion](../../epics/EPIC-05-HRIS-API-Completion.md)

--- a/docs/modules/operations/FEATURES.md
+++ b/docs/modules/operations/FEATURES.md
@@ -1,0 +1,22 @@
+# OPERATIONS Module Feature ↔ Epic Map
+
+This document links Operations capabilities to their governing epics for traceability across inventory, warehouses, stock ledger, BOMs, and costing/availability.
+
+## Feature Coverage Table
+| Feature Area | Status | Epic / Doc | Notes |
+| --- | --- | --- | --- |
+| Item Master (Items, Categories, UOM, Conversions) | ✅ Delivered | [EPIC-06 Operations Master Data](../../epics/EPIC-06-Operations-Master-Data.md#%F0%9F%93%8C-phase-1-item-master-uom) | CRUD + search, indexed by tenant and SKU/code, permissions seeded. |
+| Warehouse & Location Hierarchy | ✅ Delivered | [EPIC-06 Operations Master Data](../../epics/EPIC-06-Operations-Master-Data.md#%F0%9F%93%8C-phase-2-warehouses-stock-ledger) | Warehouses, bins/locations, opening balances; RBAC guards in place. |
+| Stock Ledger & Balances | ✅ Delivered | [EPIC-06 Operations Master Data](../../epics/EPIC-06-Operations-Master-Data.md#%F0%9F%93%8C-phase-2-warehouses-stock-ledger) | Movements (receipts, issues, transfers, adjustments) + balance snapshots. |
+| Bill of Materials (BOM) Entities & Validation | ✅ Delivered | [EPIC-06 Operations Master Data](../../epics/EPIC-06-Operations-Master-Data.md#%F0%9F%93%8C-phase-3-bom--recipes) | BOM entities, cycle detection, UOM validation, versioning model. |
+| BOM APIs (CRUD, Versioning) | 🚧 In Progress | [EPIC-06 Operations Master Data](../../epics/EPIC-06-Operations-Master-Data.md#%F0%9F%93%8C-phase-3-bom--recipes) | CRUD + activation shipped; costing & breakdown pending integration. |
+| Costing & Availability | 🚧 In Progress | [EPIC-06 Operations Master Data](../../epics/EPIC-06-Operations-Master-Data.md#%F0%9F%93%8C-phase-4-costing--availability) | Weighted-average initial design; FIFO follow-up planned; availability endpoints WIP. |
+| Documentation & DX (OpenAPI, Admin UX) | 🚧 In Progress | [EPIC-06 Operations Master Data](../../epics/EPIC-06-Operations-Master-Data.md#%F0%9F%93%8C-phase-5-documentation--dx) | OpenAPI examples done; admin UI polish/import templates pending. |
+| Advanced Cost Roll-up & MRP | 📋 Planned | [PROJECT-ROADMAP](../../PROJECT-ROADMAP.md#%F0%9F%93%86-phase-3-operational-modules) | Future roll-up, MRP, procurement integration, availability performance views. |
+
+## How to Use This File
+- **Product / Delivery** – See what’s live vs. in-flight and jump to the governing epic.
+- **Engineering** – Align feature work with epic requirements and remaining gaps.
+- **QA / Compliance** – Map test plans to the exact epic that defines each capability.
+
+For the full Operations narrative and roadmap, see `docs/modules/README.md` and the epic files under `docs/epics/`.

--- a/docs/modules/operations/README.MD
+++ b/docs/modules/operations/README.MD
@@ -1,0 +1,30 @@
+# OPERATIONS Module Overview
+
+## Purpose
+The Operations module provides foundational supply chain and production data: item master, warehouses/locations, stock movements, bills of materials, and costing/availability services. It supports manufacturing, inventory, and procurement flows while enforcing tenant and RBAC controls.
+
+## Current Picture
+| Capability | Status | Notes |
+| --- | --- | --- |
+| Item Master (Items/Categories/UOM) | ✅ Delivered | CRUD + search with tenant and SKU/code indexing. |
+| Warehouse & Locations | ✅ Delivered | Warehouses, bins/locations, opening balances. |
+| Stock Ledger & Balances | ✅ Delivered | Receipts, issues, transfers, adjustments; balance snapshots. |
+| BOM Entities & Validation | ✅ Delivered | BOM structure, cycle detection, UOM validation, versioning model. |
+| BOM APIs (CRUD/Versioning) | 🚧 In Progress | CRUD + activation shipped; costing & breakdown pending integration. |
+| Costing & Availability | 🚧 In Progress | Weighted-average initial design; FIFO follow-up planned; availability endpoints WIP. |
+| Documentation & Admin UX | 🚧 In Progress | OpenAPI examples done; admin UI polish/import templates pending. |
+| Advanced Cost Roll-up & MRP | 📋 Planned | To follow once costing + availability stabilize. |
+| Sales Orders & Fulfillment | 📋 Planned | Order capture, reservation/allocation, pick/pack/ship, invoicing handoff. |
+| Procurement & Goods Receipt | 📋 Planned | PR → PO workflow, vendor master, receiving with cost/lot/serial capture. |
+| Goods Issue & Returns | 📋 Planned | Outbound issues for sales/production/returns with RBAC and audit. |
+| Availability & Reservations | 📋 Planned | Allocations, safety stock rules, real-time availability APIs. |
+| Lot/Serial Tracking | 📋 Planned | Traceability through receipts, movements, and returns. |
+| Cycle Counts & Physical Inventory | 📋 Planned | Counting programs, recounts, and postings to the ledger. |
+| Quality & Inspection | 📋 Planned | Receiving inspection, NCRs, hold/release flows. |
+| Pricing & Catalog Hooks | 📋 Planned | Pricing tiers/agreements to support sales flows. |
+| Event Broadcast & Webhooks | 📋 Planned | Ops domain events (receipts/issues/BOM changes) emitted to central notifications/webhook service. |
+
+## References
+- [Feature ↔ Epic Map](./FEATURES.md)
+- [EPIC-06 Operations Master Data](../../epics/EPIC-06-Operations-Master-Data.md)
+- [Project Roadmap](../../PROJECT-ROADMAP.md)

--- a/docs/modules/system/FEATURES.md
+++ b/docs/modules/system/FEATURES.md
@@ -1,0 +1,20 @@
+# SYSTEM Module Feature ↔ Epic Map
+
+This reference connects each major SYSTEM capability to the epic (or roadmap item) that introduced or governs it, providing traceability across docs/epics.
+
+## Feature Coverage Table
+| Feature Area | Status | Epic / Doc | Notes |
+| --- | --- | --- | --- |
+| RBAC Platform (roles, permissions, guards) | ✅ Delivered | [EPIC-01-RBAC](../../epics/EPIC-01-RBAC.md) | Backend + frontend RBAC stack, including decorators, guards, and permission UI. |
+| Multi-tenant identity & session management | ✅ Delivered | [EPIC-01-RBAC](../../epics/EPIC-01-RBAC.md) | Covers tenant-scoped users, session revocation, and device tracking. |
+| Tenant lifecycle & provisioning automation | ✅ Delivered | [PROJECT-ROADMAP](../../PROJECT-ROADMAP.md#%F0%9F%8F%97%EF%B8%8F-phase-1-system-foundation-security) | CLI + API flows to create, suspend, and seed tenant environments. |
+| Configuration & feature flag service | ⚙️ In progress | [PROJECT-ROADMAP](../../PROJECT-ROADMAP.md#%F0%9F%8F%97%EF%B8%8F-phase-1-system-foundation-security) | Registry exists; admin UI + rollout policies being finalized. |
+| Audit logging & observability hooks | ⚙️ In progress | [PROJECT-ROADMAP](../../PROJECT-ROADMAP.md#%F0%9F%8F%97%EF%B8%8F-phase-1-system-foundation-security) | Unified event schema defined; storage adapter shipping in upcoming sprint. |
+| Delegated administration & access tooling | 📋 Planned | [EPIC-01-RBAC](../../epics/EPIC-01-RBAC.md) | Advanced approval flows + reporting slated post Phase 2 stabilization. |
+
+## How to Use This File
+- **Product / Delivery** – Quickly see which SYSTEM pieces are production-ready and which epics house their requirements.
+- **Engineers** – Jump from a feature to the authoritative epic spec when planning enhancements.
+- **QA / Audit** – Verify scope by matching the feature under test with its governing epic.
+
+> For a full platform roadmap, continue to [PROJECT-ROADMAP.md](../../PROJECT-ROADMAP.md).

--- a/docs/modules/system/README.MD
+++ b/docs/modules/system/README.MD
@@ -1,0 +1,53 @@
+# SYSTEM Module Overview
+
+## Purpose
+The SYSTEM module provides tenant-aware platform services that every other module relies on. It centralizes identity, access control, configuration, and cross-cutting orchestration so that domain modules can stay focused on their business logic while inheriting consistent governance and telemetry.
+
+## Current Implementation Snapshot
+| Capability | Status | Notes |
+| --- | --- | --- |
+| Tenant provisioning | ✅ Implemented | Multi-tenant schema separation with lifecycle hooks for seeding defaults. |
+| Authentication / sessions | ✅ Implemented | Uses JWT + refresh tokens with session revocation logic. |
+| RBAC (role-based access control) | ✅ Implemented | Hierarchical roles, permission namespaces, and policy guards wired into NestJS decorators. |
+| Audit logging | ⚙️ In progress | Structured event trail defined; storage backend being finalized. |
+| Feature flags / configuration | ⚙️ In progress | Config registry exposed; UI tooling pending. |
+
+## Conceptual Responsibilities
+1. **Tenant Management** – Create, suspend, and manage tenant metadata, including plan entitlements and data partitions.
+2. **Identity & Security** – Maintain users, service accounts, and authentication flows, enforcing password and MFA policies.
+3. **Access Control (RBAC/ABAC)** – Author role templates, assign permissions, and enforce guards at API and UI layers.
+4. **Configuration Service** – Store environment-aware settings, feature toggles, and shared constants for downstream modules.
+5. **Observability Hooks** – Emit standardized audit, metrics, and tracing events for the observability stack.
+
+## RBAC Concept
+- **Role library** – System ships with base roles (Admin, Operator, Auditor) that modules extend via scoped permissions.
+- **Permission model** – Namespaces follow `module.feature.action` format (e.g., `operations.bom.view`).
+- **Policy enforcement** – NestJS guards + decorators (`@RequireAccess`) validate permissions before controller execution.
+- **Delegated administration** – Tenant admins can assign roles per user; system safeguards high-privilege actions with approval flows (coming soon).
+
+## Feature Breakdown (Implemented Today)
+| Feature Area | Delivered Capabilities | Interfaces / Notes |
+| --- | --- | --- |
+| Tenant Lifecycle | Create, suspend, and reactivate tenants; seed default roles and settings per tenant. | CLI + Admin API endpoints; hooks tie into provisioning scripts. |
+| Identity & Sessions | Username/password login, refresh-token rotation, session revocation, MFA-ready schema. | `/auth` endpoints in NestJS; session store backed by Redis. |
+| RBAC Core | Role + permission entities, hierarchical inheritance, decorator-based guard enforcement, policy evaluation service. | `@RequireAccess` + `RequireAccessGuard` used by every module controller. |
+| Access Tooling | Admin UI to assign roles, view effective permissions, and audit access history (MVP). | React components consumed by portal + admin apps. |
+| Configuration Service | Centralized key/value store scoped by tenant + environment, runtime client for module consumption. | Exposed through `/system/config` API; typed client available to services. |
+| Observability Hooks | Structured audit event schema, log emitters, and tracing spans for critical flows. | Writes to audit topic; storage adapter finishing per roadmap. |
+
+## Integration Points
+| Consumer Module | Dependency | Rationale |
+| --- | --- | --- |
+| HRIS | Authentication, RBAC | Secure employee data and limit HR features by role. |
+| OPERATIONS | Tenant context, RBAC | Ensure BOM, inventory, and production APIs inherit tenant + permission checks. |
+| FINANCE | Audit logging | Financial transactions rely on immutable audit events. |
+
+## Roadmap Highlights
+- Finish audit log storage adapter (targeting Q2).
+- Expose configuration UI for tenant admins to toggle beta features.
+- Implement automated compliance reports (user access review exports).
+
+---
+For architecture diagrams, API references, and the detailed feature ↔ epic map, see:
+- `/docs/backend/system/`
+- [SYSTEM Feature Map](./FEATURES.md)


### PR DESCRIPTION
# 📝 Pull Request Description

## 🔍 Overview
Adds module documentation updates across System, HRIS, and Operations, including feature↔epic maps and current/planned capability breakdowns.

## 🚀 Key Changes
- **System Docs**: Added module overview and feature↔epic map; linked in root modules README.
- **HRIS Docs**: Added module overview and feature↔epic map; linked in root modules README.
- **Operations Docs**: Added module overview and feature↔epic map; expanded planned capabilities (sales, procurement, availability, lot/serial, cycle counts, quality, pricing, webhooks).
- **Modules README**: Linked module guides for System, HRIS, and Operations.

## 🔗 Related Issues/Epics
- Fixes #
- Relates to EPIC-03, EPIC-04, EPIC-05, EPIC-06 (documentation alignment)

## 🧪 Testing Performed
- [ ] Automated tests passed
- [ ] Manual verification completed
- [ ] UI/UX checked across multiple screen sizes
- Notes: Docs-only change; no tests run.

## 📸 Screenshots / Recordings
- N/A (docs-only)

## 🚩 Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings